### PR TITLE
Retire fixes

### DIFF
--- a/metacat/ui/metacat_file.py
+++ b/metacat/ui/metacat_file.py
@@ -318,7 +318,7 @@ class RetireCommand(CLICommand):
             namespace, name = args
         else:
             raise InvalidArguments("Too many arguments")
-        do_retire = not ("-u" not in opts or "--unretire" in opts)
+        do_retire = not ("-u" in opts or "--unretire" in opts)
         try:
             data = client.retire_file(did=did, namespace=namespace, name=name, retire=do_retire)
         except MCError as e:

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -135,7 +135,7 @@ class MetaCatHandler(BaseHandler):
             ns = DBNamespace.get(db, namespace)
             if ns is None:
                 raise KeyError("Namespace %s does not exist")
-            authorized = ns.owned_by_user(user)
+            authorized = ns.owned_by_user(user) or user.is_admin() 
             self.NamespaceAuthorizations[namespace] = authorized
         return authorized
 


### PR DESCRIPTION
This is one-liner fixes for #5 and #6, one is a stray "not" in the client code, the other is an update to a permissions check to allow admins to act as if they were namespace owners.