### PR TITLE
Fix #10

### DIFF
--- a/metacat/mql/meta_evaluator.py
+++ b/metacat/mql/meta_evaluator.py
@@ -12,6 +12,11 @@ class MetaEvaluator(object):
         elif attrname == "name":                x = f.Name
         elif attrname == "namespace":           x = f.Namespace
         elif attrname == "size":                x = f.Size
+        elif attrname == "retired":             x = f.Retired
+        elif attrname == "retired_by":          x = f.RetiredBy
+        elif attrname == "retired_timestamp":   x = f.RetiredTimestamp
+        elif attrname == "updated_by":          x = f.UpdatedBy
+        elif attrname == "updated_timetamp":    x = f.UpdatedTimestamp
         return x
 
     def evaluate_meta_expression(self, f, meta_expression):

--- a/metacat/mql/sql_converter.py
+++ b/metacat/mql/sql_converter.py
@@ -184,6 +184,7 @@ class SQLConverter(Ascender):
                         inner join (
                             $arg_sql
                         ) as {c} on {c}.id = {pc}.child_id
+                        where not {p}.retired
                     {order}
                 --  end of parents of {p}
             """, arg_sql=arg_sql)
@@ -212,7 +213,8 @@ class SQLConverter(Ascender):
                         inner join parent_child {pc} on {c}.id = {pc}.child_id
                         inner join (
                             $arg_sql
-                        ) as {p} on {p}.id = {pc}.parent_id
+                        ) as {p} on {p}.id = {pc}.parent_id 
+                        where not {c}.retired
                     {order}
                 -- end of children of {c}
             """, arg_sql=arg_sql)

--- a/tests/commandline.py
+++ b/tests/commandline.py
@@ -4,9 +4,9 @@ import time
 import pytest
 import json
 
-from env import env, token
+from env import env, token, auth
 
-start_ds = time.time()
+start_ds = int(time.time())
 
     
 @pytest.fixture
@@ -37,7 +37,7 @@ def tst_file_md_list():
 
 # need tests for at least:
 
-def test_metacat_help_(env):
+def test_metacat_help_(auth):
     with os.popen("metacat help 2>&1 ", "r") as fin:
         data = fin.read()
     print(f"data: '{data}'")
@@ -46,28 +46,28 @@ def test_metacat_help_(env):
     assert(data.find("login") > 0 )
     assert(data.find("version") > 0 )
 
-def test_metacat_version_(env):
+def test_metacat_version_(auth):
     with os.popen("metacat version ", "r") as fin:
         data = fin.read()
         assert(data.find("Server version") > 0)
         assert(data.find("Client version") > 0)
 
 # punting on non-token login types for now
-#def test_metacat_auth_login_x509(env, proxy):
+#def test_metacat_auth_login_x509(auth, proxy):
 #    with os.popen(f"metacat auth login -m x509 {os.environ['USER']}", "r") as fin:
 #        data = fin.read()
 #        assert(data.find(os.environ['USER']) > 0)
 #        assert(data.find("User") >= 0)
 #        assert(data.find("Expires") >= 0)
 #
-#def test_metacat_auth_login_services(env, passwd):
+#def test_metacat_auth_login_services(auth, passwd):
 #    with os.popen(f"metacat auth login -m token {os.environ['USER']}", "r") as fin:
 #        data = fin.read()
 #        assert(data.find(os.environ['USER']) > 0)
 #        assert(data.find("User") >= 0)
 #        assert(data.find("Expires") >= 0)
 
-def test_metacat_auth_login_token(env, token):
+def test_metacat_auth_login_token(auth, token):
     with os.popen(f"metacat auth login -m token {os.environ['USER']}", "r") as fin:
         data = fin.read()
         assert(data.find(os.environ['USER']) > 0)
@@ -75,7 +75,7 @@ def test_metacat_auth_login_token(env, token):
         assert(data.find("Expires") >= 0)
 
 
-def test_metacat_auth_whoami(env):
+def test_metacat_auth_whoami(auth):
     with os.popen("metacat auth whoami", "r") as fin:
         data = fin.read()
         assert(data.find(os.environ['USER']) > 0)
@@ -83,40 +83,40 @@ def test_metacat_auth_whoami(env):
         assert(data.find("Expires") >= 0)
 
 # Not bothering with proxy bits...
-#def test_metacat_auth_mydn(env):
+#def test_metacat_auth_mydn(auth):
 #    with os.popen("metacat auth mydn", "r") as fin:
 #        data = fin.read()
 #        # check output
 
 
-def test_metacat_auth_list(env):
+def test_metacat_auth_list(auth):
     with os.popen("metacat auth list", "r") as fin:
         data = fin.read()
         assert(data.find('Token library') >= 0)
         assert(data.find(f'{os.environ["USER"]}/.token_library') >= 0)
         assert(data.find(os.environ["METACAT_SERVER_URL"]) >= 0)
 
-def test_metacat_auth_export(env):
+def test_metacat_auth_export(auth):
     with os.popen(f"metacat auth export {os.environ['METACAT_SERVER_URL']}", "r") as fin:
         data = fin.read()
         assert(len(data) > 128)
 
 # punting on this for now... 
-#def test_metacat_auth_import(env):
+#def test_metacat_auth_import(auth):
 #    with os.popen("metacat auth import", "r") as fin:
 #        data = fin.read()
 
         
 # jumping some file delcaration tests first, so we then have some files
 # to make datasets of(?) 
-def test_metacat_dataset_create(env, tst_ds):
+def test_metacat_dataset_create(auth, tst_ds):
     with os.popen(f"metacat dataset create {tst_ds} ", "r") as fin:
         data = fin.read()
     assert(data.find(tst_ds) > 0)
     assert(data.find("ataset") > 0)
     assert(data.find("eated") > 0) # dont fail if they fix spelling of cteated
 
-def test_metacat_file_declare(env,tst_file_md_list, tst_ds):
+def test_metacat_file_declare(auth,tst_file_md_list, tst_ds):
     md = tst_file_md_list[0]
     with open("mdf1", "w") as mdf:
         json.dump(md, mdf);
@@ -127,7 +127,7 @@ def test_metacat_file_declare(env,tst_file_md_list, tst_ds):
     assert( data.find(md["name"]) > 0)
 
         
-def test_metacat_file_declare_many(env, tst_ds, tst_file_md_list):
+def test_metacat_file_declare_many(auth, tst_ds, tst_file_md_list):
     with open("mdf", "w") as mdf:
         json.dump(tst_file_md_list[1:], mdf)
     with os.popen(f"metacat file declare-many mdf {tst_ds}", "r") as fin:
@@ -137,7 +137,7 @@ def test_metacat_file_declare_many(env, tst_ds, tst_file_md_list):
         assert( data.find(md["name"]) > 0)
 
 
-def test_metacat_dataset_show(env, tst_ds):
+def test_metacat_dataset_show(auth, tst_ds):
     with os.popen(f"metacat dataset show {tst_ds}", "r") as fin:
         data = fin.read()
     ns,dsname = tst_ds.split(":")
@@ -146,7 +146,7 @@ def test_metacat_dataset_show(env, tst_ds):
     assert( data.find(os.environ["USER"]) > 0)
 
 
-def test_metacat_dataset_files(env, tst_ds, tst_file_md_list):
+def test_metacat_dataset_files(auth, tst_ds, tst_file_md_list):
     with os.popen(f"metacat dataset files {tst_ds}", "r") as fin:
         data = fin.read()
     # should list all the files...
@@ -154,7 +154,7 @@ def test_metacat_dataset_files(env, tst_ds, tst_file_md_list):
         assert(data.find( md["name"] ) > 0)
 
 
-def test_metacat_dataset_list(env, tst_ds):
+def test_metacat_dataset_list(auth, tst_ds):
     with os.popen(f"metacat dataset list {os.environ['USER']}:*", "r") as fin:
         data = fin.read()
     assert(data.find(tst_ds) >= 0)
@@ -162,139 +162,139 @@ def test_metacat_dataset_list(env, tst_ds):
 #=================  below here is largely unfilled-in ==========================
 #  remember to take the x_ off as you fill tghem en
 
-def x_test_metacat_dataset_add_subset(env):
+def x_test_metacat_dataset_add_subset(auth):
     with os.popen("metacat dataset add-subset", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_dataset_add_files(env):
+def x_test_metacat_dataset_add_files(auth):
     with os.popen("metacat dataset add-files", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_dataset_remove_files(env):
+def x_test_metacat_dataset_remove_files(auth):
     with os.popen("metacat dataset remove-files", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_dataset_update(env):
+def x_test_metacat_dataset_update(auth):
     with os.popen("metacat dataset update", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_dataset_remove(env):
+def x_test_metacat_dataset_remove(auth):
     with os.popen("metacat dataset remove", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_namespace_create(env):
+def x_test_metacat_namespace_create(auth):
     with os.popen("metacat namespace create", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_namespace_list(env):
+def x_test_metacat_namespace_list(auth):
     with os.popen("metacat namespace list", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_namespace_show(env):
+def x_test_metacat_namespace_show(auth):
     with os.popen("metacat namespace show", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_category_list(env):
+def x_test_metacat_category_list(auth):
     with os.popen("metacat category list", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_category_show(env):
+def x_test_metacat_category_show(auth):
     with os.popen("metacat category show", "r") as fin:
         data = fin.read()
         # check output
 
 
-def x_test_metacat_file_declare_sample(env):
+def x_test_metacat_file_declare_sample(auth):
     with os.popen("metacat file declare-sample", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_move(env):
+def x_test_metacat_file_move(auth):
     with os.popen("metacat file move", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_add(env):
+def x_test_metacat_file_add(auth):
     with os.popen("metacat file add", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_datasets(env):
+def x_test_metacat_file_datasets(auth):
     with os.popen("metacat file datasets", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_update(env):
+def x_test_metacat_file_update(auth):
     with os.popen("metacat file update", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_update_meta(env):
+def x_test_metacat_file_update_meta(auth):
     with os.popen("metacat file update-meta", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_retire(env):
+def x_test_metacat_file_retire(auth):
     with os.popen("metacat file retire", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_name(env):
+def x_test_metacat_file_name(auth):
     with os.popen("metacat file name", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_fid(env):
+def x_test_metacat_file_fid(auth):
     with os.popen("metacat file fid", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_file_show(env):
+def x_test_metacat_file_show(auth):
     with os.popen("metacat file show", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_query_q(env):
+def x_test_metacat_query_q(auth):
     with os.popen("metacat query -q", "r") as fin:
         data = fin.read()
         # check output <MQL query file>
 
-def x_test_metacat_query_mql(env):
+def x_test_metacat_query_mql(auth):
     with os.popen("metacat query", "r") as fin:
         data = fin.read()
         # check output query>"
 
-def x_test_metacat_named_query_create(env):
+def x_test_metacat_named_query_create(auth):
     with os.popen("metacat named_query create", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_named_query_show(env):
+def x_test_metacat_named_query_show(auth):
     with os.popen("metacat named_query show", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_named_query_list(env):
+def x_test_metacat_named_query_list(auth):
     with os.popen("metacat named_query list", "r") as fin:
         data = fin.read()
         # check output
 
-def x_test_metacat_named_query_search(env):
+def x_test_metacat_named_query_search(auth):
     with os.popen("metacat named_query search", "r") as fin:
         data = fin.read()
         # check output
 
 
-def x_test_metacat_validate(env):
+def x_test_metacat_validate(auth):
     with os.popen("metacat validate [options]", "r") as fin:
         data = fin.read()
         # check output <JSON file with metadata>

--- a/tests/env.py
+++ b/tests/env.py
@@ -11,5 +11,9 @@ def env():
 
 @pytest.fixture
 def token(env):
-    os.system("htgettoken -i hypot -a htvaultprod.fnal.gov")
-
+    os.system("htgettoken -i hypot -a htvaultprod.fnal.gov ")
+    
+@pytest.fixture
+def auth(token):
+    os.system("metacat auth login -m token $USER")
+    

--- a/tests/env.py
+++ b/tests/env.py
@@ -1,13 +1,23 @@
 import os
 import pytest
 
+production=False
+
 @pytest.fixture
 def env():
-    os.environ['METACAT_AUTH_SERVER_URL'] = 'https://metacat.fnal.gov:8143/auth/hypot_dev'
-    os.environ['DATA_DISPATCHER_URL'] = 'https://metacat.fnal.gov:9443/hypot_dd/data'
-    os.environ['METACAT_SERVER_URL'] = 'https://metacat.fnal.gov:9443/hypot_meta_dev/app'
-    os.environ['DATA_DISPATCHER_AUTH_URL'] = 'https://metacat.fnal.gov:8143/auth/hypot_dev'
+    if production:
+       hostaport = 'https://metacat.fnal.gov:8143'
+       hostport = 'https://metacat.fnal.gov:9443'
+    else:
+       hostaport = 'https://metacat.fnal.gov:8143'
+       hostport = 'http://fermicloud761.fnal.gov:9094'
+
+    os.environ['METACAT_AUTH_SERVER_URL'] = f'{hostaport}/auth/hypot_dev'
+    os.environ['DATA_DISPATCHER_URL'] = f'{hostport}/hypot_dd/data'
+    os.environ['METACAT_SERVER_URL'] = f'{hostport}/hypot_meta_dev/app'
+    os.environ['DATA_DISPATCHER_AUTH_URL'] = f'{hostaport}/auth/hypot_dev'
     os.environ['BEARER_TOKEN_FILE'] = '/tmp/bt_mc_test%d' % os.getpid()
+    print("METACAT_SERVER_URL=", os.environ["METACAT_SERVER_URL"])
 
 @pytest.fixture
 def token(env):

--- a/tests/issue10.py
+++ b/tests/issue10.py
@@ -14,33 +14,32 @@ def test_issue_10(auth):
         set -x
         metacat dataset create {user}:steve_test_retire_{start_ts}
         metacat file declare {user}:1mbtestfile.st2024{start_ts} {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001
-        metacat file declare {user}:1mbtestfile.st2024{start_ts}.child {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001 --parents {user}:1mbtestfile.st2024{start_ts}
+        metacat file declare {user}:1mbtestfile.st2024{start_ts}.child1 {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001 --parents {user}:1mbtestfile.st2024{start_ts}
         metacat file declare {user}:1mbtestfile.st2024{start_ts}.child2 {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001 --parents {user}:1mbtestfile.st2024{start_ts}
         metacat dataset files {user}:steve_test_retire_{start_ts}
         metacat file show {user}:1mbtestfile.st2024{start_ts} -l
-        metacat file show {user}:1mbtestfile.st2024{start_ts}.child -l
+        metacat file show {user}:1mbtestfile.st2024{start_ts}.child1 -l
         metacat file show {user}:1mbtestfile.st2024{start_ts}.child2 -l
     """)
 
     with os.popen(f"""
         set -x
         metacat query children '(files from {user}:steve_test_retire_{start_ts})'
-        metacat query parents ' (files from {user}:steve_test_retire_{start_ts})'
     """) as fin:
          out1 = fin.read()
 
     os.system(f"""
         set -x
-        metacat file retire {user}:1mbtestfile.st2024{start_ts}.child
+        metacat file retire {user}:1mbtestfile.st2024{start_ts}.child1
     """)
 
     with os.popen(f"""
         set -x
         metacat query children '(files from {user}:steve_test_retire_{start_ts})'
-        metacat query parents ' (files from {user}:steve_test_retire_{start_ts})'
     """) as fin:
          out2 = fin.read()
     
     # Make sure our file is in the pre-remove query  but  not the post remove...
-    assert(out1.find( f"{user}:1mbtestfile.st2024{start_ts}.child") >= 0)
-    assert(out2.find( f"{user}:1mbtestfile.st2024{start_ts}.child") < 0)
+    print(f"comparing: '{out1}' '{out2}'")
+    assert(out1.find( f"{user}:1mbtestfile.st2024{start_ts}.child1") >= 0)
+    assert(out2.find( f"{user}:1mbtestfile.st2024{start_ts}.child1") < 0)

--- a/tests/issue10.py
+++ b/tests/issue10.py
@@ -1,0 +1,46 @@
+import os
+import time
+import pytest
+import json
+
+from env import env, token, auth
+
+
+def test_issue_10(auth):
+    # use case from issue 10
+    start_ts = int(time.time())
+    user = os.environ["USER"]
+    os.system(f"""
+        set -x
+        metacat dataset create {user}:steve_test_retire_{start_ts}
+        metacat file declare {user}:1mbtestfile.st2024{start_ts} {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001
+        metacat file declare {user}:1mbtestfile.st2024{start_ts}.child {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001 --parents {user}:1mbtestfile.st2024{start_ts}
+        metacat file declare {user}:1mbtestfile.st2024{start_ts}.child2 {user}:steve_test_retire_{start_ts} -s 1024000 -c adler32:a0e10001 --parents {user}:1mbtestfile.st2024{start_ts}
+        metacat dataset files {user}:steve_test_retire_{start_ts}
+        metacat file show {user}:1mbtestfile.st2024{start_ts} -l
+        metacat file show {user}:1mbtestfile.st2024{start_ts}.child -l
+        metacat file show {user}:1mbtestfile.st2024{start_ts}.child2 -l
+    """)
+
+    with os.popen(f"""
+        set -x
+        metacat query children '(files from {user}:steve_test_retire_{start_ts})'
+        metacat query parents ' (files from {user}:steve_test_retire_{start_ts})'
+    """) as fin:
+         out1 = fin.read()
+
+    os.system(f"""
+        set -x
+        metacat file retire {user}:1mbtestfile.st2024{start_ts}.child
+    """)
+
+    with os.popen(f"""
+        set -x
+        metacat query children '(files from {user}:steve_test_retire_{start_ts})'
+        metacat query parents ' (files from {user}:steve_test_retire_{start_ts})'
+    """) as fin:
+         out2 = fin.read()
+    
+    # Make sure our file is in the pre-remove query  but  not the post remove...
+    assert(out1.find( f"{user}:1mbtestfile.st2024{start_ts}.child") >= 0)
+    assert(out2.find( f"{user}:1mbtestfile.st2024{start_ts}.child") < 0)


### PR DESCRIPTION
This is the fix for #10 of retired files resulting from parent/child queries.
We just add a `where not xx.retired ` clause in the parentage query,
as well as including retired_by, etc. in the query parser.

Also we add a test case based on the issue #10 reproduction notes (which were excellent, thanks!)

There are also some updates in the main test suite, changing the fixture required, which looks like
a lot of changes, but is one global search&replace...