### PR TITLE
Logging

### DIFF
--- a/tests/env.py
+++ b/tests/env.py
@@ -49,7 +49,7 @@ def tst_ds():
 def tst_file_md_list():
     ds = start_ds
     mdl = []
-    for i in range(5):
+    for i in range(15):
         fname = f"tst_{ds}_{i}.txt"
         fcont = f"data file {fname}\n"
         with open(fname, "w") as fo:

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -100,7 +100,7 @@ def test_metacat_auth_export(auth):
 # need to first create a namespace for the username
 # also test that the second time it's created fails
 def test_initial_namespace_create(auth):
-    os.popen(f'metacat namespace create {os.environ["USER"]}')
+    os.system(f'metacat namespace create {os.environ["USER"]}')
     with os.popen(f'metacat namespace create {os.environ["USER"]} 2>&1', "r") as fin:
         data = fin.read()
     assert data.find("exists") > 0

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -97,6 +97,13 @@ def test_metacat_auth_export(auth):
 #    with os.popen("metacat auth import", "r") as fin:
 #        data = fin.read()
 
+# need to first create a namespace for the username
+# also test that the second time it's created fails
+def test_initial_namespace_create(auth):
+    os.popen(f'metacat namespace create {os.environ["USER"]}')
+    with os.popen(f'metacat namespace create {os.environ["USER"]} 2>&1', "r") as fin:
+        data = fin.read()
+    assert data.find("exists") > 0
 
 # jumping some file delcaration tests first, so we then have some files
 # to make datasets of(?)
@@ -158,16 +165,6 @@ def test_metacat_query_q(auth, tst_file_md_list, tst_ds):
         assert data.find(md["name"]) >= 0
 
 
-def test_metacat_query_q(auth, tst_file_md_list, tst_ds):
-    with open("qfl1", "w") as qf:
-        qf.write(f"files from {tst_ds}")
-    with os.popen("metacat query -q qfl1", "r") as fin:
-        data = fin.read()
-    os.unlink("qfl1")
-    for md in tst_file_md_list[:-1]:
-        assert data.find(md["name"]) >= 0
-
-
 def test_metacat_query_mql(auth, tst_file_md_list, tst_ds):
     with os.popen(f"metacat query files from {tst_ds}", "r") as fin:
         data = fin.read()
@@ -191,11 +188,11 @@ def test_metacat_dataset_add_subset(auth, tst_ds):
 
 def test_metacat_dataset_add_files(auth, tst_ds):
     query = (
-        f'(files where creator="{os.environ["USER"]}") - (files from {tst_ds}) limit 10'
+        f'((files where creator="{os.environ["USER"]}") - (files from {tst_ds} limit 10)) limit 2'
     )
     with os.popen(f"metacat dataset add-files --query '{query}' {tst_ds} ", "r") as fin:
         data = fin.read()
-    assert data.find("Added 10 files") >= 0
+    assert data.find("Added 2 files") >= 0
 
 
 def test_metacat_dataset_update_fail(auth, tst_ds):

--- a/webserver/Server.py
+++ b/webserver/Server.py
@@ -14,6 +14,7 @@ from urllib.parse import quote_plus, unquote_plus
 
 from metacat.util import to_str, to_bytes
 from metacat.common import SignedToken, SignedTokenExpiredError, SignedTokenImmatureError, SignedTokenUnacceptedAlgorithmError, SignedTokenSignatureVerificationError
+from metacat.logs import Logged, Logger
 
 from metacat import Version
 from wsdbtools import ConnectionPool
@@ -87,6 +88,11 @@ class App(BaseApp, Primitive):
         
         self.StaticLocation = static_location
 
+        config_name = os.environ.get("METACAT_SERVER_CFG")
+        instance_name = config_name.split("/")[1].split(".")[0]
+        log_file = "logs/%s.log" % instance_name
+        self.Logger = Logger(log_file)
+
         self.StandardFilters = {}
         self.CustomFilters = {}
 
@@ -148,6 +154,8 @@ def create_application(config=None, prefix=None):
     if config is None:
         print("Configuration file must be provided using METACAT_SERVER_CFG environment variable")
         return None
+    else:
+        os.environ["METACAT_SERVER_CFG"] = config
     if isinstance(config, str):
         config = yaml.load(open(config, "r"), Loader=yaml.SafeLoader)  
     cookie_path = config.get("cookie_path", "/metacat")


### PR DESCRIPTION
Enabled more metacat client error messages to be logged:
- Log messages will now appear in the log files for each metacat instance.
- Made the ordering of the error code and message consistent across all the methods in data_handler.py.
- Also fixed #41. Added an error message for create_dataset as mentioned in the issue, and for create_namespace and add_child_dataset as well.

Included some minor improvements to the testing:
- Added a test to create a namespace for the username, and to test that it fails if the namespace already exists.
- Increased the number of files in the test dataset to help with the metacat dataset add files test, so if the user running the tests doesn't have any files in metacat yet it this test should still work.
- Removed a test that looked like an exact duplicate.