### PR TITLE
metacat file show with out -j or -p and with  null values in database…

### DIFF
--- a/metacat/ui/metacat_file.py
+++ b/metacat/ui/metacat_file.py
@@ -437,14 +437,14 @@ class ShowCommand(CLICommand):
             pprint.pprint(data)
         else:
             for k, v in sorted(data.items()):
-                if k == "checksums":
+                if k == "checksums" and v:
                     print("checksums:")
                     for typ, cksum in sorted(v.items()):
                         print("    %-10s: %s" % (typ, cksum))
-                elif k == "created_timestamp":
+                elif k == "created_timestamp" and v:
                     t = datetime.fromtimestamp(v, timezone.utc)
                     print("%-20s:\t%s" % (k, t))
-                elif k not in ("metadata", "parents", "children", "datasets"):
+                elif k not in ("metadata", "parents", "children", "datasets") and v:
                     print("%-20s:\t%s" % (k, v))
 
             if "metadata" in data:

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -366,6 +366,16 @@ def test_metacat_file_show(auth, tst_file_md_list, tst_ds):
     assert data.find(ns) >= 0
     assert json.loads(data)
 
+def test_metacat_file_show2(auth, tst_file_md_list, tst_ds):
+    # make sure file name and fid are consistent
+    fname = tst_file_md_list[3]["name"]
+    ns = tst_file_md_list[3]["namespace"]
+    with os.popen(f"metacat file show -m {ns}:{fname}", "r") as fin:
+        data = fin.read()
+    assert data.find(fname) >= 0
+    assert data.find(ns) >= 0
+    assert json.loads(data)
+
 
 def test_metacat_validate_good(auth, tst_file_md_list, tst_ds):
     md = tst_file_md_list[0]["metadata"]


### PR DESCRIPTION
… sometimes blows stack trace in ui code. 
Simple check value tests seem to fix it. 