### PR TITLE
Fix for INC000001185162 / Issue #60

### DIFF
--- a/metacat/db/dbobjects2.py
+++ b/metacat/db/dbobjects2.py
@@ -510,7 +510,7 @@ class DBFile(DBObject):
             """,
             (self.FID, self.Namespace, self.Name, meta, self.Size, checksums, creator,
 
-                datetime.fromtimestamp(f.CreatedTimestamp).isoformat() if self.CreatedTimestamp else null))
+                datetime.fromtimestamp(f.CreatedTimestamp).isoformat() if self.CreatedTimestamp else datetime.now()))
         self.CreatedTimestamp = c.fetchone()[0]
         if self.Parents:
             insert_many(self.DB,
@@ -543,7 +543,7 @@ class DBFile(DBObject):
                 f.Size if f.Size is not None else null,
                 json.dumps(f.Checksums) if f.Checksums else '{}',
                 f.Creator or creator or null,
-                datetime.fromtimestamp(f.CreatedTimestamp).isoformat() if f.CreatedTimestamp else null,
+                datetime.fromtimestamp(f.CreatedTimestamp).isoformat() if f.CreatedTimestamp else datetime.now(),
             ))
             f.Creator = f.Creator or creator
             if f.Parents:

--- a/tests/test_issue33.py
+++ b/tests/test_issue33.py
@@ -69,7 +69,8 @@ def test_metacat_file_declare_many_33(auth, tst_ds_33, tst_file_md_list_33):
     assert data.find(tst_file_md_list_33[0]["name"]) > 0
     assert data.find(tst_file_md_list_33[1]["name"]) > 0
     # also check issue #60
-    assert data.find('"created_timestamp": 1') > 0
+    assert data.find('"created_timestamp"') > 0
+    assert data.find('"created_timestamp": null') < 0
 
 
 def test_update_33(auth, tst_ds_33, tst_file_md_list_33):

--- a/tests/test_issue33.py
+++ b/tests/test_issue33.py
@@ -68,6 +68,8 @@ def test_metacat_file_declare_many_33(auth, tst_ds_33, tst_file_md_list_33):
     # check response for requested parents
     assert data.find(tst_file_md_list_33[0]["name"]) > 0
     assert data.find(tst_file_md_list_33[1]["name"]) > 0
+    # also check issue #60
+    assert data.find('"created_timestamp": 1') > 0
 
 
 def test_update_33(auth, tst_ds_33, tst_file_md_list_33):


### PR DESCRIPTION
Since we can pass in a value for created_timestamp now, we need to pass the current time in if we weren't giving one;
inserting a null value doesn't give the default.

This does that; and also adds a check to one of our tests that the created_timestamp is set to something starting with "1", 
which I suppose we have to change 