### PR TITLE
Handle plugin failures

### DIFF
--- a/metacat/filters/__init__.py
+++ b/metacat/filters/__init__.py
@@ -1,1 +1,1 @@
-from .filters import MetaCatFilter, standard_filters, load_filters_module
+from .filters import MetaCatFilter, standard_filters

--- a/metacat/filters/filters.py
+++ b/metacat/filters/filters.py
@@ -198,22 +198,3 @@ standard_filters = {
     "randomize":    Randomize()
 }
 
-def load_filters_module(module_name, env, config):
-    import os
-    from importlib import import_module
-    saved_environ = None
-    if env:
-        saved_environ = os.environ.copy()
-        os.environ.update(env)
-    try:
-        mod = import_module(module_name)
-        filters = mod.create_filters(config)
-    finally:
-        if saved_environ:
-            for k in env.keys():
-                if k in saved_environ:
-                    os.environ[k] = saved_environ[k]
-                else:
-                    del os.environ[k]
-    return filters
-

--- a/webserver/Server.py
+++ b/webserver/Server.py
@@ -89,7 +89,7 @@ class App(BaseApp, Primitive):
         self.StaticLocation = static_location
 
         config_name = os.environ.get("METACAT_SERVER_CFG")
-        instance_name = config_name.split("/")[1].split(".")[0]
+        instance_name = config_name.split("/")[-1].split(".")[0]
         log_file = "logs/%s.log" % instance_name
         self.Logger = Logger(log_file)
 


### PR DESCRIPTION
This makes it so that a failed plugin will not bring down the entire metacat server instance, which fixes #56. It will log the error, and normal metacat queries will continue to run. Trying to use the failed plugin will result in an MQLExecutionError, which will also be logged.

Also added a small fix for the name of the log files, which changed after we switched from Igor's multiserver setup to use uwsgi. Now we should have a separate log file for each instance again, instead of home.log.