### PR TITLE
Batching query results (implements #65) 

### DIFF
--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -863,10 +863,11 @@ MetaCat queries are written in :doc:`Metadata Query Language <mql>`.
             -S|--save-as=<namespace>:<name>     - save files as a new datset
             -A|--add-to=<namespace>:<name>      - add files to an existing dataset
             -r|--include-retired-files          - include retired files into the query results
+            -b|--batch_size N                   - request results in batches of N files
 
             -x|--explain                        - do not run the query, show resulting SQL only
         
-
+The --batch_size N option is useful for queries that otherwise time out.
     
 Named Queries
 -------------

--- a/metacat/ui/cli/cli.py
+++ b/metacat/ui/cli/cli.py
@@ -82,8 +82,8 @@ class CLIInterpreter(object):
             else:
                 opts, args = getopt.getopt(argv, short_opts, long_opts)
             #print(self, ".getopt(): opts, args:", opts, args)
-        except getopt.GetoptError:
-            raise InvalidOptions()
+        except getopt.GetoptError as e:
+            raise InvalidOptions(message=str(e))
         if len(args) < self.MinArgs:
             raise InvalidArguments()
         return self.make_opts_dict(opts), args

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1304,6 +1304,8 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                 url += f"&namespace={namespace}"
             if include_retired_files:
                 url += "&include_retired_files=yes"
+            results = self.post_json(url, query)
+            return results
         else:
             url = "data/query?with_meta=%s&with_provenance=%s" % ("yes" if with_metadata else "no","yes" if with_provenance else "no")
             if namespace:
@@ -1314,9 +1316,8 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                 url += f"&add_to={add_to}"
             if include_retired_files:
                 url += "&include_retired_files=yes"
-        #print("url:", url)
-        results = self.post_json(url, query)
-        return results
+            results = self.post_json(url, query)
+            return results
 
     def async_query(self, query, data=None, **args):
         """Run the query asynchronously. Requires client authentication if save_as or add_to are used.

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1316,8 +1316,17 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                 url += f"&add_to={add_to}"
             if include_retired_files:
                 url += "&include_retired_files=yes"
-            results = self.post_json(url, query)
-            return results
+            batch_size = 500
+            offset = 0
+            count = batch_size
+            while count == batch_size:
+                batch_query = f"({query}) skip {offset} limit {batch_size}"
+                results = self.post_json(url, batch_query)
+                count = 0
+                for item in results:
+                    count = count + 1
+                    yield item
+                offset = offset + batch_size
 
     def async_query(self, query, data=None, **args):
         """Run the query asynchronously. Requires client authentication if save_as or add_to are used.

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1320,7 +1320,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                 offset = 0
                 count = batch_size
                 while count == batch_size:
-                    batch_query = f"({query}) skip {offset} limit {batch_size}"
+                    batch_query = f"({query}) ordered skip {offset} limit {batch_size}"
                     results = self.post_json(url, batch_query)
                     count = 0
                     for item in results:

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1329,7 +1329,8 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                     offset = offset + batch_size
             else:
                 results = self.post_json(url, query)
-                return results
+                for item in results:
+                    yield item
 
     def async_query(self, query, data=None, **args):
         """Run the query asynchronously. Requires client authentication if save_as or add_to are used.

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1261,7 +1261,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
             return None
 
     def query(self, query, namespace=None, with_metadata=False, with_provenance=False, save_as=None, add_to=None,
-                        include_retired_files=False, summary=None, batch_size=500):
+                        include_retired_files=False, summary=None, batch_size=0):
         """Run file query. Requires client authentication if save_as or add_to are used.
         
         Arguments

--- a/tests/env.py
+++ b/tests/env.py
@@ -14,8 +14,7 @@ if not production:
 
 @pytest.fixture
 def env():
-    #if production:
-    if True:
+    if production:
        hostaport = 'https://metacat.fnal.gov:8143'
        hostport = 'https://metacat.fnal.gov:9443'
     else:

--- a/tests/env.py
+++ b/tests/env.py
@@ -14,7 +14,8 @@ if not production:
 
 @pytest.fixture
 def env():
-    if production:
+    #if production:
+    if True:
        hostaport = 'https://metacat.fnal.gov:8143'
        hostport = 'https://metacat.fnal.gov:9443'
     else:

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -370,7 +370,7 @@ def test_metacat_file_show(auth, tst_file_md_list, tst_ds):
     assert 'fid' in md
     assert md['name'] == fname
     assert md['namespace'] == ns
-    assert md['size'] == 39
+    assert md['size'] == 38
     assert md['created_timestamp'] > 0
     assert md['creator'] == os.environ["USER"]
     assert 'updated_timestamp' in md

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -370,7 +370,7 @@ def test_metacat_file_show(auth, tst_file_md_list, tst_ds):
     assert 'fid' in md
     assert md['name'] == fname
     assert md['namespace'] == ns
-    assert md['size'] == 38
+    assert md['size'] in (38, 39) 
     assert md['created_timestamp'] > 0
     assert md['creator'] == os.environ["USER"]
     assert 'updated_timestamp' in md

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -181,6 +181,12 @@ def test_metacat_query_mql(auth, tst_file_md_list, tst_ds):
     for md in tst_file_md_list[:-1]:
         assert data.find(md["name"]) >= 0
 
+def test_metacat_query_mql_batch_size(auth, tst_file_md_list, tst_ds):
+    with os.popen(f"metacat query --batch_size=2 files from {tst_ds}", "r") as fin:
+        data = fin.read()
+    for md in tst_file_md_list[:-1]:
+        assert data.find(md["name"]) >= 0
+
 
 def test_metacat_dataset_list(auth, tst_ds):
     with os.popen(f"metacat dataset list {os.environ['USER']}:*", "r") as fin:


### PR DESCRIPTION

This patch uses limit/offset in a loop to perform queries in 500-file batches, to implement feature #65. 
The idea is to make more, smaller queries, which:
* complete  more quickly
* keep database rows locked less
* don't time out when used as generators for loops that work on many files.

