### PR TITLE
Namespace rules

### DIFF
--- a/docs/server_installation.rst
+++ b/docs/server_installation.rst
@@ -81,6 +81,38 @@ Running MetaCat server as a Docker Container
         $ cd <top of cloned MetaCat repository>/docker/server
         $ ./run.sh -c /path/to/config -p <external TCP port>
 
+Configuring Namespace Restriction
+---------------------------------
+
+If you would like to have special namespace creation rules, for example only
+allowing regular users to create a namespace "user.username"
+for their username, and namepaces starting with "production." 
+to the production_group group, and no others you can add a ``namespace_rules`` 
+section to the server configuration file:
+
+    .. code-block::
+       
+        namespace_rules:
+          - regex: 'user\.(.*)'
+            owner: '\\1'
+            allowed_creator: '\\1'
+          - regex: 'production\..*'
+            owner: production_group
+            allowed_creator: production_group
+          - regex: 'calibration\..*'
+            owner: calibration_group
+            allowed_creator: calibration_group
+          - regex: '.*'
+            owner: *
+            allowed_creator: no_such_group_exists
+
+[the '\\1' strings refer to the first parenthisezed match in the regexp]
+
+The first "regex" to match in the list wins, so you can put a
+``regex: '.*'`` case at the at the end for "everything else".
+Note that "admin" users can always create namespaces, regardless
+of such rules.
+
 
 Configuring LDAP Authentication
 -------------------------------

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -370,7 +370,7 @@ def test_metacat_file_show(auth, tst_file_md_list, tst_ds):
     assert 'fid' in md
     assert md['name'] == fname
     assert md['namespace'] == ns
-    assert md['size'] == 39
+    assert md['size'] in [38,39]
     assert md['created_timestamp'] > 0
     assert md['creator'] == os.environ["USER"]
     assert 'updated_timestamp' in md

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -170,3 +170,57 @@ class MetaCatHandler(BaseHandler, Logged):
             content_type = "text/plain"
         self.log('%s' % message)
         return code, text, content_type
+
+    def namespace_create_common(self, current_user, name, owner_role, description):
+        """ Namespace creation code that was going to be repeated in 
+            both the gui an data handlers"""
+
+        nsrules = self.App.Cfg.get("namespace_rules", [])
+        default_owner_user = current_user.Username
+
+        if nsrules:
+            allowed = False
+            for rule in nsrules:
+                cr_regex = re.compile(rule["regex"])
+                if cr_regex.match(name):
+                    #self.log( f"namespace create: matched rule: {repr(rule)}")
+                    rule_user = cr_regex.sub(name, rule["owner"])
+                    rule_roles = list(cr_regex.sub(name, rule["allowed_creator"]).split(","))
+
+                    if user.is_admin() or user.Username in rule_roles or '*' in rule_roles:
+                        allowed = True
+
+                    for role in rule_roles:
+                        r = DBRole.get(db, role)
+                        if r and user.Username in r.members:
+                             allowed = True
+                    if allowed:
+                        break
+            if allowed:
+                if rule_user != '*':
+                    default_owner_user = rule_user
+            else:
+                return None
+        else:
+            if owner_role:
+                r = DBRole.get(db, owner_role)
+                if not user.is_admin() and not user.Username in r.members:
+                    return 403, None 
+
+        if owner_role is None:
+            owner_user = default_owner_user
+       
+        if DBNamespace.exists(db, name):
+            return  409, None
+
+        if description:
+            description = unquote_plus(description)
+            
+        ns = DBNamespace(db, name, owner_user=owner_user, owner_role = owner_role, description=description)
+        ns.Creator = user.Username
+        ns.create()
+
+        return 200, ns
+
+
+

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -177,6 +177,7 @@ class MetaCatHandler(BaseHandler, Logged):
 
         nsrules = self.App.Cfg.get("namespace_rules", [])
         default_owner_user = current_user.Username
+        db = self.App.connect()
 
         if nsrules:
             allowed = False
@@ -187,12 +188,12 @@ class MetaCatHandler(BaseHandler, Logged):
                     rule_user = cr_regex.sub(name, rule["owner"])
                     rule_roles = list(cr_regex.sub(name, rule["allowed_creator"]).split(","))
 
-                    if user.is_admin() or user.Username in rule_roles or '*' in rule_roles:
+                    if current_user.is_admin() or current_user.Username in rule_roles or '*' in rule_roles:
                         allowed = True
 
                     for role in rule_roles:
                         r = DBRole.get(db, role)
-                        if r and user.Username in r.members:
+                        if r and current_user.Username in r.members:
                              allowed = True
                     if allowed:
                         break
@@ -204,7 +205,7 @@ class MetaCatHandler(BaseHandler, Logged):
         else:
             if owner_role:
                 r = DBRole.get(db, owner_role)
-                if not user.is_admin() and not user.Username in r.members:
+                if not current_user.is_admin() and not current_user.Username in r.members:
                     return 403, None 
 
         if owner_role is None:
@@ -217,7 +218,7 @@ class MetaCatHandler(BaseHandler, Logged):
             description = unquote_plus(description)
             
         ns = DBNamespace(db, name, owner_user=owner_user, owner_role = owner_role, description=description)
-        ns.Creator = user.Username
+        ns.Creator = current_user.Username
         ns.create()
 
         return 200, ns

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -185,18 +185,21 @@ class MetaCatHandler(BaseHandler, Logged):
                 cr_regex = re.compile(rule["regex"])
                 if cr_regex.match(name):
                     #self.log( f"namespace create: matched rule: {repr(rule)}")
-                    rule_user = cr_regex.sub(name, rule["owner"])
-                    rule_roles = list(cr_regex.sub(name, rule["allowed_creator"]).split(","))
+                    rule_user = cr_regex.sub(rule["owner"], name,1)
+                    rule_roles = list(cr_regex.sub(rule["allowed_creator"],name,1).split(","))
 
+                    #self.log( f"namespace create: rule_roles: {repr(rule_roles)}")
+                    #self.log( f"namespace create: rule_user: {repr(rule_user)}")
                     if current_user.is_admin() or current_user.Username in rule_roles or '*' in rule_roles:
+                        #self.log( f"username match")
                         allowed = True
 
                     for role in rule_roles:
                         r = DBRole.get(db, role)
                         if r and current_user.Username in r.members:
+                             #self.log( f"role member match")
                              allowed = True
-                    if allowed:
-                        break
+                    break
             if allowed:
                 if rule_user != '*':
                     default_owner_user = rule_user

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -200,7 +200,7 @@ class MetaCatHandler(BaseHandler, Logged):
                 if rule_user != '*':
                     default_owner_user = rule_user
             else:
-                return None
+                return 403, None
         else:
             if owner_role:
                 r = DBRole.get(db, owner_role)

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -124,8 +124,6 @@ class DataHandler(MetaCatHandler):
         
     @sanitized
     def create_namespace(self, request, relpath, name=None, owner_role=None, description=None, **args):
-        db = self.App.connect()
-        nsrules = self.App.Cfg.get("namespace_rules", [])
         
         self.sanitize(owner_role, name)
         
@@ -133,7 +131,7 @@ class DataHandler(MetaCatHandler):
         if user is None:
             return 401, error
 
-        code, ns = self.create_common(user, name, owner_role, description)
+        code, ns = self.namespace_create_common(user, name, owner_role, description)
         if not ns:
                return code, "Permission Denied" if code=="403" else "Namespace already exists"
         return json.dumps(ns.to_jsonable()), "application/json"

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -133,9 +133,6 @@ class DataHandler(MetaCatHandler):
         if user is None:
             return 401, error
 
-        owner_user = None
-        default_owner_user = user.Username
-
         code, ns = self.create_common(user, name, owner_role, description)
         if not ns:
                return code, "Permission Denied" if code=="403" else "Namespace already exists"

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -134,6 +134,7 @@ class DataHandler(MetaCatHandler):
             return 401, error
 
         owner_user = None
+        default_owner_user = user.Username
 
         if nsrules:
             allowed = False
@@ -154,7 +155,8 @@ class DataHandler(MetaCatHandler):
                     if allowed:
                         break
             if allowed:
-                owner_user = rule_user
+                if rule_user != '*':
+                    default_owner_user = rule_user
             else:
                return 403, "Permission denied"
         else:
@@ -164,7 +166,7 @@ class DataHandler(MetaCatHandler):
                     return 403, "Permission denied"
 
         if owner_role is None:
-            owner_user = user.Username
+            owner_user = default_owner_user
        
         if DBNamespace.exists(db, name):
             return 400, "Namespace already exists", "text/plain"

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -151,11 +151,11 @@ class DataHandler(MetaCatHandler):
                              allowed = True
                     if allowed:
                         break
-             if allowed:
-                 owner_user = rule_user
-             else:
-                return 403, "Permission denied"
-        else       
+            if allowed:
+                owner_user = rule_user
+            else:
+               return 403, "Permission denied"
+        else:
             if owner_role:
                 r = DBRole.get(db, owner_role)
                 if not user.is_admin() and not user.Username in r.members:

--- a/webserver/gui_handler.py
+++ b/webserver/gui_handler.py
@@ -801,12 +801,10 @@ class GUIHandler(MetaCatHandler):
         assert (owner_user is None) != (owner_role is None)
 
         if ns is None:
-            # create new
-            if not admin:
-                if owner_user and owner_user != me.Username or \
-                    owner_role and not owner_role in me.roles:
-                        self.redirect("./namespaces?error=%s" % (quote_plus("Not authorized"),))                    
-            ns = DBNamespace(db, name, owner_role=owner_role, owner_user=owner_user, description=description).create()
+            owner_role = request.POST.get("owner_role",None)
+            code, ns = self.namespace_create_common(me, name, owner_role, description, owner_user):
+            if code == 403:
+                self.redirect("./namespaces?error=%s" % (quote_plus("Not authorized"),))                    
         else:
             if not admin and not ns.owned_by_user(me):
                 self.redirect("./namespaces?error=%s" % (quote_plus("Not authorized"),))

--- a/webserver/gui_handler.py
+++ b/webserver/gui_handler.py
@@ -802,7 +802,7 @@ class GUIHandler(MetaCatHandler):
 
         if ns is None:
             owner_role = request.POST.get("owner_role",None)
-            code, ns = self.namespace_create_common(me, name, owner_role, description, owner_user):
+            code, ns = self.namespace_create_common(me, name, owner_role, description, owner_user)
             if code == 403:
                 self.redirect("./namespaces?error=%s" % (quote_plus("Not authorized"),))                    
         else:


### PR DESCRIPTION
Allow a namespace_rules stanza in the config that modifies namespace creation permissions.
Examples:
```  
namespace_rules:
  - regex: .*
    owner: *
    allowed_roles: admin_role
```
this means that only admins can create namespaces. 
```  
namespace_rules:
  - regex: user(.*)
    owner: \1
    allowed_roles: \1
  - regex: .*
    owner: *
    allowed_roles: admin_role
```
which means users can create their own user.username group for their username which will belong to them, but all other namespaces are only allowed to be created by admins.