### PR TITLE
Add a token_update method 

### DIFF
--- a/metacat/common/auth_client.py
+++ b/metacat/common/auth_client.py
@@ -44,6 +44,15 @@ class TokenAuthClientMixin(object):
     def tokens_saved(self):
         return self.TokenLib is not None and self.TokenLib.exists()
 
+    def token_update(self):
+        if self.tokens_saved():
+            try:
+                curtime = time.time()
+                libtime = os.stat(self.TokenLib.file).st_mtime
+                if self.Token.expiration - 10 < curtime() and libtime > curtime - 10800:
+                     self.Token = self.TokenLib.Token, _  = self.TokenLibload_library([self.TokenLib.location])
+                     self.Token = self.TokenLib.Token
+
     def login_digest(self, username, password, save_token=False):
         """Performs password-based authentication and stores the authentication token locally.
         

--- a/metacat/common/auth_client.py
+++ b/metacat/common/auth_client.py
@@ -52,8 +52,8 @@ class TokenAuthClientMixin(object):
                 #if self.Token.expiration - 10 < curtime() and libtime > curtime - 10800:
                 # for testing, refresh after 3 hours -10 sec = 10790 sec
                 if self.Token.expiration - 10790  < curtime() and libtime > curtime - 10800:
-                     self.Token = self.TokenLib.Token, _  = self.TokenLibload_library([self.TokenLib.location])
-                     self.Token = self.TokenLib.Token
+                     self.TokenLib.Tokens, _  = self.TokenLib.load_library([self.TokenLib.Location])
+                     self.Token = self.TokenLib.get(self.ServiceURL)
             except:
                 raise
 

--- a/metacat/common/auth_client.py
+++ b/metacat/common/auth_client.py
@@ -3,6 +3,8 @@ from metacat.common import SignedToken, TokenLib
 import time, requests, json
 
 import urllib3      # disable "Unverified HTTPS request is being made..." warning
+import os
+
 urllib3.disable_warnings()
 del urllib3
 
@@ -47,11 +49,8 @@ class TokenAuthClientMixin(object):
     def token_update(self):
         if self.tokens_saved():
             try:
-                curtime = time.time()
-                libtime = os.stat(self.TokenLib.file).st_mtime
-                #if self.Token.expiration - 10 < curtime() and libtime > curtime - 10800:
-                # for testing, refresh after 3 hours -10 sec = 10790 sec
-                if self.Token.expiration - 10790  < curtime() and libtime > curtime - 10800:
+                libtime = os.stat(self.TokenLib.Location).st_mtime
+                if  libtime > self.TokenLib.LoadTime:
                      self.TokenLib.Tokens, _  = self.TokenLib.load_library([self.TokenLib.Location])
                      self.Token = self.TokenLib.get(self.ServiceURL)
             except:

--- a/metacat/common/auth_client.py
+++ b/metacat/common/auth_client.py
@@ -49,9 +49,14 @@ class TokenAuthClientMixin(object):
             try:
                 curtime = time.time()
                 libtime = os.stat(self.TokenLib.file).st_mtime
-                if self.Token.expiration - 10 < curtime() and libtime > curtime - 10800:
+                #if self.Token.expiration - 10 < curtime() and libtime > curtime - 10800:
+                # for testing, refresh after 3 hours -10 sec = 10790 sec
+                if self.Token.expiration - 10790  < curtime() and libtime > curtime - 10800:
                      self.Token = self.TokenLib.Token, _  = self.TokenLibload_library([self.TokenLib.location])
                      self.Token = self.TokenLib.Token
+            except:
+                raise
+
 
     def login_digest(self, username, password, save_token=False):
         """Performs password-based authentication and stores the authentication token locally.

--- a/metacat/common/token_lib.py
+++ b/metacat/common/token_lib.py
@@ -1,6 +1,7 @@
 import os, os.path, stat
 from .signed_token_jwt import SignedToken, SignedTokenExpiredError, SignedTokenImmatureError
 from metacat.util import to_bytes, to_str
+import time
 
 class TokenLib(object):
 
@@ -13,6 +14,7 @@ class TokenLib(object):
                 ]
             else:
                 locations = [path]
+            self.LoadTime = 0
             self.Tokens, self.Location = self.load_library(locations)
             if not self.Location and create:
                 # not found
@@ -23,6 +25,7 @@ class TokenLib(object):
                 try:    
                     open(path, "w").close()         # create empty library
                     os.chmod(path, stat.S_IRUSR | stat.S_IWUSR )
+                    self.LoadTime = time.time()
                     return path
                 except: pass
             return None
@@ -35,6 +38,7 @@ class TokenLib(object):
                         #print("loading tokens from:", path)
                         tokens = self.load_from_file(path)
                         #print("tokens loaded from:", path)
+                        self.LoadTime = time.time()
                         return tokens, path
                     except:
                         pass

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -1,0 +1,31 @@
+# this one first, so we can find metacat, etc.
+from env import env, token
+from metacat.webapi import MetaCatClient, AuthenticationError, MCError
+
+# other imports
+import pytest
+import time
+import os
+
+@pytest.fixture
+def client(token):
+    return MetaCatClient()
+
+@pytest.fixture
+def bearer_token():
+    token = os.environ.get("BEARER_TOKEN")
+    if not token:
+        token_file = os.environ.get("BEARER_TOKEN_FILE")
+        if not token_file:
+            uid = os.environ.get("ID", str(os.geteuid()))
+            token_dir = os.environ.get("XDG_RUNTIME_DIR", "/tmp")
+            token_file = token_dir + "/" + "bt_u" + uid
+    token = open(token_file, "r").read().strip()
+    return token
+
+def test_token_auth(client, bearer_token):
+    user, expiration = client.login_token(os.environ["USER"], bearer_token)
+    assert(user == os.environ["USER"])
+    assert(expiration > time.time())
+    print(f"Authenticated as {user}")
+


### PR DESCRIPTION

This pull request adds a method to the metacat (and data_dispatcher) clients, token_update()
which pulls in an updated authentication token if the token file is newer than when we first loaded it.

Calling this regularly will let long-running scripts which keep their client object open take advantage of
an external program which is updating their metacat token file. 