### PR TITLE
Fix 74

### DIFF
--- a/metacat/ui/metacat_query.py
+++ b/metacat/ui/metacat_query.py
@@ -99,15 +99,16 @@ class QueryCommand(CLICommand):
                         batch_size=batch_size
             )
 
-            #print("client.query results:", repr(results))
 
             in_line = "-l" in opts or "--line" in opts
             print_format = "json" if ("--json" in opts or "-j" in opts) \
                 else ("pprint" if "--pretty" in opts or "-p" in opts else "text")
 
-    
+
             if summary == "count":
+                results = list(results)[0]
                 if print_format == "text":
+                    sys.stdout.flush()
                     nfiles = results["count"]
                     total_size = results["total_size"]
                     print("Files:       ", nfiles)
@@ -134,7 +135,7 @@ class QueryCommand(CLICommand):
                 else:
                     pprint.pprint(results)
             elif summary == "keys":
-                results = list(results)
+                results = list(results)[0]
                 #print(results)
                 results = sorted(results)
                 if print_format == "text":

--- a/metacat/ui/metacat_query.py
+++ b/metacat/ui/metacat_query.py
@@ -104,11 +104,10 @@ class QueryCommand(CLICommand):
             print_format = "json" if ("--json" in opts or "-j" in opts) \
                 else ("pprint" if "--pretty" in opts or "-p" in opts else "text")
 
-
+    
             if summary == "count":
                 results = list(results)[0]
                 if print_format == "text":
-                    sys.stdout.flush()
                     nfiles = results["count"]
                     total_size = results["total_size"]
                     print("Files:       ", nfiles)

--- a/metacat/version.py
+++ b/metacat/version.py
@@ -1,4 +1,4 @@
-Version = "4.1.0_rc1"
+Version = "4.1.0"
 
 if __name__ == "__main__":
     print(Version)

--- a/metacat/version.py
+++ b/metacat/version.py
@@ -1,4 +1,4 @@
-Version = "4.0.2"
+Version = "4.1.0_rc1"
 
 if __name__ == "__main__":
     print(Version)

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1281,8 +1281,8 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         add_to : str
             namespace:name for an existing dataset to add found files to
         summary : str or None
-            "count" - return file count only as int
-            "keys" - return list of all top level metadata keys for the selected files
+            "count" - return [{"count": n, "total_size": nbytes }]
+            "keys" - return list of list of all top level metadata keys for the selected files
             ``summary`` can not be used together with ``save_as`` or ``add_to``
 
         Returns
@@ -1294,10 +1294,10 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         -----
         Retrieving file provenance and metadata takes slightly longer time
         """
-        
+
         assert not (summary is not None and (add_to or save_as)), "Summary can not be used together with add_to or save_as"
         assert summary in ("count", "keys", None)
-        
+
         if summary:
             url = f"data/query?summary={summary}"
             if namespace:
@@ -1305,7 +1305,8 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
             if include_retired_files:
                 url += "&include_retired_files=yes"
             results = self.post_json(url, query)
-            return results
+            yield results
+            return
         else:
             url = "data/query?with_meta=%s&with_provenance=%s" % ("yes" if with_metadata else "no","yes" if with_provenance else "no")
             if namespace:

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -181,6 +181,19 @@ def test_metacat_query_mql(auth, tst_file_md_list, tst_ds):
     for md in tst_file_md_list[:-1]:
         assert data.find(md["name"]) >= 0
 
+def test_metacat_query_mql_count(auth, tst_file_md_list, tst_ds):
+    with os.popen(f"metacat query --summary count files from {tst_ds}", "r") as fin:
+        data = fin.read()
+    lines = data.split("\n")
+    assert int(lines[0][6:]) == len(tst_file_md_list)
+
+def test_metacat_query_mql_keys(auth, tst_file_md_list, tst_ds):
+    with os.popen(f"metacat query --summary keys files from {tst_ds}", "r") as fin:
+        data = fin.read()
+    md = tst_file_md_list[0]["metadata"]
+    for k in md:
+        assert(data.find(k) >= 0)
+
 def test_metacat_query_mql_batch_size(auth, tst_file_md_list, tst_ds):
     with os.popen(f"metacat query --batch_size=2 files from {tst_ds}", "r") as fin:
         data = fin.read()

--- a/webserver/common_handler.py
+++ b/webserver/common_handler.py
@@ -171,12 +171,15 @@ class MetaCatHandler(BaseHandler, Logged):
         self.log('%s' % message)
         return code, text, content_type
 
-    def namespace_create_common(self, current_user, name, owner_role, description):
+    def namespace_create_common(self, current_user, name, owner_role, description, owner_user=''):
         """ Namespace creation code that was going to be repeated in 
             both the gui an data handlers"""
 
         nsrules = self.App.Cfg.get("namespace_rules", [])
-        default_owner_user = current_user.Username
+        if owner_user:
+            default_owner_user = owner_user
+        else:
+            default_owner_user = current_user.Username
         db = self.App.connect()
 
         if nsrules:


### PR DESCRIPTION

In 4.1.0 we made the webapi/ MetaCatClient.query() method a generator function, to support batched
queries for long results; but we forgot to change the summary options accordingly.   This fixes that, but does change the values returned with the summary flag to a singleton list of the old values.
Note that summary="count" was mis-documented already as just returning an int, when it returned a dict of {"count": n, "total_bytes": m}, and now returns [{"count": n, "total_bytes": m}]