### PR TITLE
convert 'ordered' to be order by created_timestamp,file_id...

### DIFF
--- a/metacat/mql/sql_converter.py
+++ b/metacat/mql/sql_converter.py
@@ -81,7 +81,7 @@ class SQLConverter(Ascender):
                     select {t}.*
                     from (
                         $child_sql
-                    ) {t} order by {t}.id
+                    ) {t} order by {t}.created_timestamp,{t}.id
                 -- end of ordered {t}
             """, child_sql = child_sql)
             return Node("sql", sql=sql)
@@ -174,7 +174,7 @@ class SQLConverter(Ascender):
             c = alias("c")
             pc = alias("pc")
             columns = self.columns(p, with_meta, with_provenance)
-            order = f"order by {p}.id" if ordered else ""
+            order = f"order by {p}.created_timestamp,{p}.id" if ordered else ""
             table = "files_with_provenance" if with_provenance else "files"
             new_sql = insert_sql(f"""\
                 --  parents of {p}
@@ -204,7 +204,7 @@ class SQLConverter(Ascender):
             c = alias("c")
             pc = alias("pc")
             columns = self.columns(c, with_meta, with_provenance)
-            order = f"order by {p}.id" if ordered else ""
+            order = f"order by {p}.created_timestamp,{p}.id" if ordered else ""
             table = "files_with_provenance" if with_provenance else "files"
             new_sql = insert_sql(f"""\
                 -- children of {c}


### PR DESCRIPTION

Unlike SAM, which had monotonically increasing file ids, MetaCat does not, so ordering by file_id is not remotely time ordered.

Example:
<pre>
hypot_dm_dev=> select id, created_timestamp from files order by id limit 10;
        id        |       created_timestamp       
------------------+-------------------------------
 03K4lIl5Sjq8W5wG | 2023-08-24 18:16:35.72046-05
 04v0RUOVTm2ONp58 | 2024-03-18 11:33:08.487976-05
 05cK7X4QS9ih8J3a | 2025-04-23 14:47:12.895553-05
 06fNt2RRROiTTEhp | 2024-07-26 15:57:20.987397-05
 07Fgyt5AQlazWTG2 | 2024-07-31 12:14:18.0535-05
 08J76uY2TJap8nY8 | 2025-05-13 10:19:05.48382-05
 09DDbeLUSsq8bbEN | 2023-10-09 17:20:26.442766-05
 0AO6u7DIRl6ALoFL | 2024-03-26 17:07:28.175146-05
 0bbuF9SOR9yjNJTC | 2025-04-14 11:53:10.136526-05
 0BzFQSYLSz2mgztH | 2024-07-26 15:42:44.985137-05
</pre>

So if you are slicing using offset/lmit queries, ordering by file_id doesn't prevent new files from bumping the
sequence for you so you'll see files twice, etc.   This change will order by created_timestamp and then id, 
so new files are always at the end and slicing by offset/limit will be consistent. 
