### PR TITLE
Adding 'checksums' as a query parameter

### DIFF
--- a/docs/mql.rst
+++ b/docs/mql.rst
@@ -123,6 +123,7 @@ The following are file attributes which can be used in a file query:
      * id
      * namespace
      * name
+     * checksums
      * creator
      * updated_by
      * created_timestamp

--- a/metacat/common/attributes.py
+++ b/metacat/common/attributes.py
@@ -1,7 +1,7 @@
 FileAttributes = [      # file attributes which can be used in queries
             "creator", "created_timestamp", "name", "namespace", "size",
             "retired", "retired_by", "retired_timestamp", "updated_by",  
-            "updated_timestamp"
+            "updated_timestamp", "checksums"
 ]  
 
 DatasetAttributes = [

--- a/metacat/mql/grammar/file_query.py
+++ b/metacat/mql/grammar/file_query.py
@@ -36,6 +36,6 @@ params_list : constant_list         // convert date, datetime to floats
 file_query_list: file_query ("," file_query)*     
 
 // file attributes
-FILE_ATTR_NAME: ("id" | "namespace" | "name" | "creator" | "updated_by" | "created_timestamp" | "updated_timestamp" | "retired" | "retired_by" | "retired_timestamp" )
+FILE_ATTR_NAME: ("id" | "namespace" | "name" | "creator" | "updated_by" | "created_timestamp" | "updated_timestamp" | "retired" | "retired_by" | "retired_timestamp" | "checksums" )
 
 """

--- a/metacat/mql/meta_evaluator.py
+++ b/metacat/mql/meta_evaluator.py
@@ -17,6 +17,7 @@ class MetaEvaluator(object):
         elif attrname == "retired_timestamp":   x = f.RetiredTimestamp
         elif attrname == "updated_by":          x = f.UpdatedBy
         elif attrname == "updated_timestamp":   x = f.UpdatedTimestamp
+        elif attrname == "checksums":           x = f.Checksums
         return x
 
     def evaluate_meta_expression(self, f, meta_expression):

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -189,6 +189,12 @@ def test_metacat_query_mql(auth, tst_file_md_list, tst_ds):
     for md in tst_file_md_list[:-1]:
         assert data.find(md["name"]) >= 0
 
+def test_metacat_query_mql_checksums(auth, tst_file_md_list, tst_ds):
+    with os.popen(f"metacat query \"files from {tst_ds} where checksums != '{{}}'\"", "r") as fin:
+        data = fin.read()
+    for md in tst_file_md_list[:-1]:
+        assert data.find(md["name"]) >= 0
+
 def test_metacat_query_mql_count(auth, tst_file_md_list, tst_ds):
     with os.popen(f"metacat query --summary count files from {tst_ds}", "r") as fin:
         data = fin.read()


### PR DESCRIPTION
Add 'checksums' as a query parameter for file queries.

Then you can 
  `  metacat query "files from myns:mydataset where checksums = '{}' "`
to look for files without checksums, etc.

This gets added in the docs, the query grammar, a keyword check list, the metadata evaluator that converts to sql, and in a test.