### PR TITLE
Full word options to metacat auth login

### DIFF
--- a/metacat/ui/metacat_auth.py
+++ b/metacat/ui/metacat_auth.py
@@ -94,8 +94,8 @@ class WhoAmICommand(CLICommand):
             print ("Expires:", time.ctime(expiration))
         
 def get_x509_cert_key(opts):
-    cert = opts.get("-c") or os.environ.get("X509_USER_PROXY") or os.environ.get("X509_USER_CERT")
-    key = opts.get("-k") or os.environ.get("X509_USER_KEY") or cert
+    cert = opts.get("-c") or opts.get("--cert") or os.environ.get("X509_USER_PROXY") or os.environ.get("X509_USER_CERT")
+    key = opts.get("-k") or opts.get("--key") or os.environ.get("X509_USER_KEY") or cert
     if not cert:
         print("X.509 certificate file is unspecified.\n")
         print("  Use -c <cert file> or set env. variable X509_USER_PROXY or X509_USER_CERT")
@@ -140,7 +140,7 @@ class LoginCommand(CLICommand):
 
     def __call__(self, command, client, opts, args):
         username = args[0]
-        mechanism = opts.get("-m", "password")
+        mechanism = opts.get("-m", opts.get("--method", "password"))
         if mechanism == "password":
             password = getpass.getpass("Password:")
             user, expiration = client.login_password(username, password)

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -49,6 +49,13 @@ def test_metacat_version_(auth):
 #        assert(data.find("Expires") >= 0)
 
 
+def test_metacat_auth_login_long_token(auth, token):
+    with os.popen(f"metacat auth login --method token {os.environ['USER']}", "r") as fin:
+        data = fin.read()
+        assert data.find(os.environ["USER"]) > 0
+        assert data.find("User") >= 0
+        assert data.find("Expires") >= 0
+
 def test_metacat_auth_login_token(auth, token):
     with os.popen(f"metacat auth login -m token {os.environ['USER']}", "r") as fin:
         data = fin.read()


### PR DESCRIPTION
The `metacat auth login` command  is supposed to have long options (--method , --cert, --key) but they were not actually implemented in the code.  This PR fixes that. 