### PR TITLE
Adding roles and role membership from FERRY FQANs

### DIFF
--- a/conversion_mwm/sam_parser/new_query_converter.py
+++ b/conversion_mwm/sam_parser/new_query_converter.py
@@ -3,9 +3,9 @@
 import sys
 import os
 import re
+from parser import DimParserError
 from parse_tree import *
 from random import random, randint, choice, seed
-from parser import DimParserError
 import parser
 import logging
 

--- a/conversion_mwm/sam_parser/parse_tree.py
+++ b/conversion_mwm/sam_parser/parse_tree.py
@@ -3,6 +3,7 @@
 import re
 import logging
 from pyparsing import ParseResults
+import parser
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +15,11 @@ class DimParseTreeError:
 
 
 def is_set_level_node( tree ):
+    logging.debug(f"is_set_level_node( {tree.__class__} )")
     for t in [ SetNode, DefinitionNode, MetaFilterNode, IsRelativeOfNode, WithNode, MetaDatasetNode ]:
         if isinstance(tree, t):
-            return t
+            return True
+    return False
 
 def meta_render_dimensions_tree(tree):
     """Pretty print the dimensions tree"""
@@ -293,12 +296,15 @@ class SetNode(BinaryOperatorNode, NegatableNode):
         return hash((BinaryOperatorNode.__hash__(self), self.negated))
 
     def meta_render(self):
+        if self.negated:
+            raise NotImplementedError("cannot negate set operations in Metacat")
         notnonelen = sum([1 for n in self.nodes if n])
+        if  notnonelen == 0:
+            return 
         if  notnonelen == 1:
             return self.nodes[0].meta_render()
-        if self.negated:
-            yield "not"
-            yield "("
+        # debugging
+        # yield f"[{notnonelen=} {repr(self.nodes)}]"
         if self.op in ("union", "intersect"):
             if self.op == "intersect":
                 m_op = "join"
@@ -321,8 +327,6 @@ class SetNode(BinaryOperatorNode, NegatableNode):
         else:
             for t in BinaryOperatorNode.meta_render(self):
                 yield t
-        if self.negated:
-            yield ")"
 
     def render(self):
         if self.negated:
@@ -977,9 +981,12 @@ class MetaCatTransformer(ParseTreeTransformer):
         return True
 
     def parent_sets(self, offset = 0):
-        if self.ptdepth  < 2:
+        logging.debug(f"parent_sets: {self.ptdepth=} {[x.__class__ for x in self.node_path]}")
+        if self.ptdepth < 2:
             return True
-        return is_set_level_node(self.node_path[self.ptdepth - 2])
+        res = is_set_level_node(self.node_path[self.ptdepth - 2])
+        logging.debug(f"parent_sets: returning {res}")
+        return  res
 
     def setboundary(self):
         if self.ptdepth > 0:
@@ -997,8 +1004,8 @@ class MetaCatTransformer(ParseTreeTransformer):
             self.node_path.append(node)
         else:
             self.node_path[self.ptdepth] = node
-        logging.debug(f"visiting {node}")
         self.ptdepth = self.ptdepth + 1
+        logging.debug(f"visiting {self.ptdepth=} {node=}")
         #actually visit
         node = ParseTreeTransformer.visit(self, node)
         #bookkeeping
@@ -1008,6 +1015,11 @@ class MetaCatTransformer(ParseTreeTransformer):
         # now add hoisted subtrees..
         if self.setboundary():
             
+            logging.debug(f"hoisting:")
+            logging.debug(f"{self.proj_terms=}")
+            logging.debug(f"{self.rse_terms=}")
+            logging.debug(f"{self.parentage_terms=}")
+            logging.debug(f"{self.snapshot_terms=}")
             if self.proj_terms:
                 self.modified = True
                 if len(self.proj_terms) > 1:
@@ -1071,8 +1083,10 @@ class MetaCatTransformer(ParseTreeTransformer):
         if node.dim in self.snapshot_dims:
             self.modified = True
             if self.parent_sets():
+                logging.debug(f"snapshot dim rendered here: {repr(node)}")
                 return MetaDatasetNode(node.value)
             else:
+                logging.debug(f"snapshot dim pushed up: {repr(node)}")
                 self.snapshot_terms.append(node)
                 return None
         return node
@@ -1089,8 +1103,10 @@ class MetaCatTransformer(ParseTreeTransformer):
     def visit_IsRelativeOfNode(self, node):
         if node.subtree:
             if self.parent_sets():
+               logging.debug(f"expanding here: {repr(node)}")
                return IsRelativeOfNode(node.relation, self.visit(node.subtree))
          
+            logging.debug(f"bumping up: {repr(node)}")
             self.parentage_terms.append(IsRelativeOfNode(node.relation,self.visit(node.subtree)))
         return None
 
@@ -1116,6 +1132,7 @@ class MetaCatTransformerPart2(ParseTreeTransformer):
         #  filter rucio_replicas () (files where pred1) where pred2 )
         # and similar
 
+        logging.debug(f"visit_SetNode: here, {repr(node.nodes)}")
         hangunder = None
         tohang = None
         i=0
@@ -1141,6 +1158,10 @@ class MetaCatTransformerPart2(ParseTreeTransformer):
         # fix 'join(files something, files where)'
         if node.op == 'intersect' and isinstance(node.nodes[1],BinaryOperatorNode) and not node.nodes[1].nodes:
              node = node.nodes[0]
+
+        if node.op == 'intersect' and isinstance(node.nodes[1],IsRelativeOfNode):
+             if node.nodes[1].subtree == None:
+                 node = node.nodes[0]
 
         return node
              
@@ -1207,6 +1228,17 @@ def formatTree(tree):
     return " ".join(formatter.visit(tree))
 
 
+def SAM_query_to_MetaCat(dims):
+    t = parser.parse_string(dims)
+    #logging.debug("parse tree: ", str(t), "\n\n")
+    #logging.debug("-------------------")
+    mt = MetaCatTransformer().visit(t)
+    mt = MetaCatTransformerPart2().visit(mt)
+    #logging.debug("meta tree: ", str(mt), "\n\n")
+    meta = meta_render_dimensions_tree(mt)
+    return meta
+
+
 __all__ = [
     "DimNode",
     "WithNode",
@@ -1226,4 +1258,5 @@ __all__ = [
     "meta_render_dimensions_tree",
     "MetaCatTransformer",
     "MetaCatTransformerPart2",
+    "SAM_query_to_MetaCat",
 ]

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -40,11 +40,22 @@ class MetaCatDaemon(Logged):
         self.CountsUpdateInterval = daemon_config.get("counts_update_interval", 1 * 3600)
         self.VO = daemon_config["vo"]
 
+        role_pattern_txt = daemon_config.get("role_pattern", "")
+        if role_pattern_txt: 
+            self.role_pattern = re.compile(role_pattern_txt)
+        else:
+            self.role_pattern = None
+
+        self.role_template = daemon_config.get("role_template", "")
+
         db_config = config["database"]
         self.DBConnect = "host=%(host)s port=%(port)s dbname=%(dbname)s user=%(user)s" % db_config
         if "password" in db_config:
             self.DBConnect += " password=%(password)s" % db_config
+
+
         self.Schema = db_config.get("schema")
+
 
         self.Queue = TaskQueue(5, delegate=self)
         self.Queue.append(self.ferry_update, interval=self.FerryUpdateInterval, after=time.time())
@@ -82,13 +93,8 @@ class MetaCatDaemon(Logged):
         db.close()
         self.log("Namespace file counts updated")
 
-    @log_exceptions
-    def ferry_update(self):
-        self.debug("ferry_update...")
-        url = f"{self.FerryURL}/getAffiliationMembersRoles?unitname={self.VO}"
 
-        # Authentication...
-        self.debug("ferry URL:", url)
+    def do_auth(self):
         if self.CertFile:
             cert = (self.CertFile, self.KeyFile)
         else:
@@ -100,7 +106,13 @@ class MetaCatDaemon(Logged):
             headers = {"Authorization": "Bearer " + token}
         else:
             headers = None
+        return cert, headers
 
+
+    def fetch_url(self, url):
+
+        self.debug("ferry URL:", url)
+        cert, headers = self.do_auth()
         response = requests.get(url, verify=False, cert=cert, headers=headers)
         data = response.json()
         self.debug("data received")
@@ -111,6 +123,44 @@ class MetaCatDaemon(Logged):
             for line in data["ferry_error"]:
                 print(line)
             raise ValueError(f"Ferry error: {data['ferry_error']}")
+
+        return data
+
+    def ferry_user_roles(self, user):
+        self.debug(f"ferry_user_roles: {user}")
+        url = f"{self.FerryURL}/getUserFQANs?username={user}&unitname={self.VO}"
+
+        data = self.fetch_url(url)
+
+        for item in data["ferry_output"]: 
+            m = self.role_pattern.search(item["fqan"])
+            if m:
+                # substitute subexpressions from pattern match
+                rolename = self.role_template
+                for i,val in enumerate(m.groups)
+                    rolename = rolename.replace(f"${i}", val)
+
+                do_save = False
+                db = self.db()
+                role = BaseDBRole.get(db, rolename):
+
+                if not role:
+                    self.debug(f"creating new role {rolename}")
+                    role = BaseDBRole(db, role, "auto-imported from FERRY")
+                    role.save()
+                    
+                if not user in role.members():
+                    self.debug(f"adding {user} to {rolename}")
+                    role.add_member(user)
+
+                return
+
+    @log_exceptions
+    def ferry_update(self):
+        self.debug("ferry_update...")
+        url = f"{self.FerryURL}/getAffiliationMembersRoles?unitname={self.VO}"
+
+        data = self.fetch_url(url)
 
         ferry_users = {item["username"]: item for item in data["ferry_output"][self.VO]}
         self.log("Loaded", len(ferry_users), "users from Ferry")
@@ -150,6 +200,9 @@ class MetaCatDaemon(Logged):
                     db_user.save()
                     nupdated += 1
                     updated.append(username)
+
+            if self.role_pattern:
+                self.ferry_user_roles(username)
 
         self.log("created:", len(created), "" if not created else ",".join(created))
         self.log("updated:", len(updated), "" if not updated else ",".join(updated))

--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -1,6 +1,6 @@
-import json, requests, time, psycopg2
+import json, requests, time, psycopg2, re
 from pythreader import TaskQueue
-from metacat.db import DBUser, DBNamespace, DBDataset, DBFile
+from metacat.db import DBUser, DBNamespace, DBDataset, DBFile, DBRole
 from metacat.logs import Logged, init as init_logs
 from wsdbtools import ConnectionWithTransactions
 import functools, traceback
@@ -137,23 +137,25 @@ class MetaCatDaemon(Logged):
             if m:
                 # substitute subexpressions from pattern match
                 rolename = self.role_template
-                for i,val in enumerate(m.groups)
+                for i,val in enumerate(m.groups(), start=1):
                     rolename = rolename.replace(f"${i}", val)
+                if rolename.find('$') >= 0:
+                    self.debug(f"role template from {item['fqan']} still has '$' : {rolename}, skipping")
+                    continue
 
                 do_save = False
                 db = self.db()
-                role = BaseDBRole.get(db, rolename):
+                role = DBRole.get(db, rolename)
 
                 if not role:
                     self.debug(f"creating new role {rolename}")
-                    role = BaseDBRole(db, role, "auto-imported from FERRY")
+                    role = DBRole(db, rolename, "auto-imported from FERRY")
                     role.save()
                     
-                if not user in role.members():
+                if not user in role.members:
                     self.debug(f"adding {user} to {rolename}")
                     role.add_member(user)
 
-                return
 
     @log_exceptions
     def ferry_update(self):
@@ -224,6 +226,7 @@ def main():
         print(Usage)
         sys.exit(2)
 
+
     config = yaml.load(open(opts["-c"], "r"), Loader=yaml.SafeLoader)
     log_file = opts.get("-l", "-")
     init_logs(log_file, error_out=log_file, debug_out=log_file, debug_enabled="-d" in opts)
@@ -231,7 +234,6 @@ def main():
     daemon = MetaCatDaemon(config)
     while True:
         time.sleep(10)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION

This PR lets you add a pair of configuration options to fetch FQAN info from FERRY, and ones that 
match a Role=... pattern you give it will be added as Roles in metacat, and users who have that FQAN
will be put in that role; implmenting #113 

If the configuration options are not given, this should do nothing. 


The config file additions needed are:

```
daemon:
  role_pattern: Role=(.*)(read|write)
  role_template: $1_$2

```