### PR TITLE
Make CLI exit codes different for different failures

### DIFF
--- a/conversion_mwm/sam_parser/random_gen.py
+++ b/conversion_mwm/sam_parser/random_gen.py
@@ -130,8 +130,12 @@ if __name__ == "__main__":
     print(t)
     print("-------")
     dims = render_dimensions_tree(t)
+       
     print(dims)
     print("======")
+    if len(dims) > 4096:
+       print("too long!")
+       sys.exit(0)
     mt = MetaCatTransformer().visit(t)
     mt = MetaCatTransformerPart2().visit(mt)
     meta = meta_render_dimensions_tree(mt)

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -64,8 +64,36 @@ In general, the command looks like this:
         $ export METACAT_SERVER_URL="http://server:port/path"
         $ export METACAT_AUTH_SERVER_URL="http://auth_server:port/auth_path"
         $ metacat <command group> <command> [command options] [arguments ...]
-        
 
+Exit Codes
+----------
+
+The in 4.1.5 and later, the metacat command will exit with different exit codes for different errors: 
+
+====    ====================================================
+Code    Description                                     
+----    ----------------------------------------------------
+   1    Invalid option                                  
+   2    Digest authentication config error              
+   3    User does not exist / is not administrator      
+   4    DB Config error                                 
+   5    User already exists                             
+   7    File not found                                  
+   8    Token file not found                            
+   9    Cannot access token file                        
+  10    Token or token file missing                     
+  11    Dataset not found                               
+  12    X.509 certificate file not specified            
+  13    Invalid metadata keys specified                 
+  14    Deprecated command refused                      
+  15    METACAT_SERVER_URL not specified                
+  16    Item already exists                             
+  17    Permission denied                               
+  19    Errors in namespace move                        
+ >32    Other exception                                 
+ 108    Authentication Failed (token exprired, etc)     
+====    ====================================================
+        
 Versions
 --------
 

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -68,20 +68,19 @@ In general, the command looks like this:
 Exit Codes
 ----------
 
-The in 4.1.5 and later, the metacat command will exit with different exit codes for different errors: 
+In metacat version 4.1.5 and later, the metacat command will exit with different exit codes for different errors: 
 
 ====    ====================================================
 Code    Description                                     
 ----    ----------------------------------------------------
    1    Invalid option                                  
    2    Digest authentication config error              
-   3    User does not exist / is not administrator      
+   3    User is not administrator or does not exist
    4    DB Config error                                 
    5    User already exists                             
    7    File not found                                  
-   8    Token file not found                            
-   9    Cannot access token file                        
-  10    Token or token file missing                     
+   8    Token file not found or not accessible
+  10    No token to export / not authenticated
   11    Dataset not found                               
   12    X.509 certificate file not specified            
   13    Invalid metadata keys specified                 

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -91,6 +91,7 @@ Code    Description
   19    Errors in namespace move                        
  >32    Other exception:
   67    Metadata parameter without a category
+  81    Alternate metadata parameter error
  108    Authentication Failed (token exprired, etc)     
 ====    ====================================================
         

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -79,7 +79,7 @@ Code    Description
    4    DB Config error                                 
    5    User already exists                             
    7    File not found                                  
-   8    Token file not found or not accessible
+   8    Metacat Token library file not found or not accessible
   10    No token to export / not authenticated
   11    Dataset not found                               
   12    X.509 certificate file not specified            

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -73,8 +73,8 @@ In metacat version 4.1.5 and later, the metacat command will exit with different
 ====    ====================================================
 Code    Description                                     
 ----    ----------------------------------------------------
-   1    Invalid option                                  
-   2    Digest authentication config error              
+   1    Invalid command-line option                                  
+   2    Digest authentication configuration error              
    3    User is not administrator or does not exist
    4    DB Config error                                 
    5    User already exists                             
@@ -86,10 +86,11 @@ Code    Description
   13    Invalid metadata keys specified                 
   14    Deprecated command refused                      
   15    METACAT_SERVER_URL not specified                
-  16    Item already exists                             
+  16    Item already exists on server
   17    Permission denied                               
   19    Errors in namespace move                        
- >32    Other exception                                 
+ >32    Other exception:
+  67    Metadata parameter without a category
  108    Authentication Failed (token exprired, etc)     
 ====    ====================================================
         

--- a/metacat/ui/common.py
+++ b/metacat/ui/common.py
@@ -6,15 +6,21 @@ from metacat.webapi import MCError
 from metacat.util import ObjectSpec
 import sys, json, os.path
 
+def exit_code_from_exception(e):
+    if isinstance(e, Exception):
+        msg = f"Exception: {e.__class__.__name__} {' '.join(e.args)}"
+        print(msg, file=sys.stderr)
+    else:
+        msg = str(e)
+    error_code = sum([ord(c) for c in msg]) % 63 + 32
+    return error_code
+
 def catch_mc_errors(method):
     def decorated(*params, **args):
         try:
             return method(*params, **args)
         except MCError as e:
-            print(e, file=sys.stderr)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
     return decorated
 
 def load_text(arg):

--- a/metacat/ui/common.py
+++ b/metacat/ui/common.py
@@ -12,7 +12,9 @@ def catch_mc_errors(method):
             return method(*params, **args)
         except MCError as e:
             print(e, file=sys.stderr)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
     return decorated
 
 def load_text(arg):

--- a/metacat/ui/common.py
+++ b/metacat/ui/common.py
@@ -3,16 +3,30 @@
 #
 
 from metacat.webapi import MCError
+from metacat.webapi.webapi import NotFoundError,WebAPIError,InvalidMetadataError
 from metacat.util import ObjectSpec
 import sys, json, os.path
 
 def exit_code_from_exception(e):
-    if isinstance(e, Exception):
-        msg = f"Exception: {e.__class__.__name__} {' '.join(e.args)}"
+    if isinstance(e, NotFoundError):
+        msg = f"Exception: not found: {e.args}"
         print(msg, file=sys.stderr)
+        error_code=12
+    elif isinstance(e, InvalidMetadataError):
+        msg = f"Exception: {e.__class__.__name__}: {str(e)}"
+        print(msg, file=sys.stderr)
+        error_code = sum([ord(c) for c in msg[:20]]) % 63 + 32
+    elif isinstance(e, WebAPIError):
+        msg = f"Exception: {e.__class__.__name__}: {e.Message}"
+        print(msg, file=sys.stderr)
+        error_code = sum([ord(c) for c in msg[:20]]) % 63 + 32
+    elif isinstance(e, Exception):
+        msg = f"Exception: {e.__class__.__name__} {' '.join([str(x) for x in e.args])}"
+        print(msg, file=sys.stderr)
+        error_code = sum([ord(c) for c in msg[:20]]) % 63 + 32
     else:
         msg = str(e)
-    error_code = sum([ord(c) for c in msg]) % 63 + 32
+        error_code = sum([ord(c) for c in msg[:20]]) % 63 + 32
     return error_code
 
 def catch_mc_errors(method):

--- a/metacat/ui/metacat_admin.py
+++ b/metacat/ui/metacat_admin.py
@@ -50,7 +50,7 @@ class CreateAdminCommand(CLICommand):
         u = DBUser.get(db, username)
         if u is not None:
             print("User already exists. Leaving users status unchanged. Use 'metacat admin add ...'")
-            sys.exit(1)
+            sys.exit(5)
         u = DBUser(db, username, "Admin", "", "a", {}, None)
         u.set_password(realm, password)
         u.save()
@@ -80,7 +80,7 @@ class PasswordCommand(CLICommand):
         u = DBUser.get(db, username)
         if u is None or not u.is_admin():
             print("User does not exist or is not an Admin. Leaving the password unchanged.")
-            sys.exit(1)
+            sys.exit(3)
         u.set_password(realm, password)
         #print("hashed password:", hashed)
         u.save()
@@ -98,7 +98,7 @@ class AddCommand(CLICommand):
         u = DBUser.get(db, username)
         if u is None or u.is_admin():
             print("User does not exist or is an Admin already.")
-            sys.exit(1)
+            sys.exit(3)
         u.Flags = (u.Flags or "") + "a"
         u.save()
         print("Admin privileges added")
@@ -115,7 +115,7 @@ class RemoveCommand(CLICommand):
         u = DBUser.get(db, username)
         if u is None or not u.is_admin():
             print("User does not exist or is not an Admin.")
-            sys.exit(1)
+            sys.exit(3)
         u.Flags = (u.Flags or "").replace("a", "")
         u.save()
         print("Admin privileges removed")
@@ -205,7 +205,7 @@ class AdminCLI(CLI):
         import yaml
         if "-c" not in opts:
             print("Database configuration must be specified with -c", file=sys.stderr)
-            sys.exit(2)
+            sys.exit(4)
         cfg = yaml.load(open(opts["-c"], "r"), Loader=yaml.SafeLoader)
         return cfg
 

--- a/metacat/ui/metacat_auth.py
+++ b/metacat/ui/metacat_auth.py
@@ -100,7 +100,7 @@ def get_x509_cert_key(opts):
         print("X.509 certificate file is unspecified.\n")
         print("  Use -c <cert file> or set env. variable X509_USER_PROXY or X509_USER_CERT")
         print(Usage)
-        sys.exit(2)
+        sys.exit(12)
     return cert, key
     
 class MyDNCommand(CLICommand):
@@ -164,17 +164,17 @@ class LoginCommand(CLICommand):
                 if token_file:
                     if not os.path.isfile(token_file):
                         print("File not found:", token_file, file=sys.stderr)
-                        sys.exit(1)
+                        sys.exit(7)
                     token = open(token_file, "r").read().strip()
             if not token:
                 print("Token not found", file=sys.stderr)
-                sys.exit(1)
+                sys.exit(8)
             user, expiration = client.login_token(username, token)
         else:
             raise InvalidArguments(f"Unknown authentication mechanism {mechanism}")
         if not client.tokens_saved():
             print("Authentication token not saved. Can not access/create token library", sys.stderr)
-            sys.exit(1)
+            sys.exit(9)
         print ("User:   ", user)
         print ("Expires:", time.ctime(expiration))
     
@@ -191,7 +191,7 @@ class ExportCommand(CLICommand):
             token = client.Token
             if token is None:
                 print(Usage)
-                sys.exit(2)
+                sys.exit(10)
         else:
             tl = client.TokenLib
             token_id_or_url = args[0]
@@ -200,7 +200,7 @@ class ExportCommand(CLICommand):
                     break
             else:
                 print("Token not found", file=sys.stderr)
-                sys.exit(1)
+                sys.exit(10)
 
         out_path = opts.get("-o", opts.get("--out"))
         if out_path:

--- a/metacat/ui/metacat_auth.py
+++ b/metacat/ui/metacat_auth.py
@@ -174,7 +174,7 @@ class LoginCommand(CLICommand):
             raise InvalidArguments(f"Unknown authentication mechanism {mechanism}")
         if not client.tokens_saved():
             print("Authentication token not saved. Can not access/create token library", sys.stderr)
-            sys.exit(9)
+            sys.exit(8)
         print ("User:   ", user)
         print ("Expires:", time.ctime(expiration))
     
@@ -200,7 +200,7 @@ class ExportCommand(CLICommand):
                     break
             else:
                 print("Token not found", file=sys.stderr)
-                sys.exit(10)
+                sys.exit(8)
 
         out_path = opts.get("-o", opts.get("--out"))
         if out_path:

--- a/metacat/ui/metacat_dataset.py
+++ b/metacat/ui/metacat_dataset.py
@@ -6,7 +6,7 @@ from metacat.util import to_bytes, to_str, epoch, ObjectSpec
 from metacat.webapi import MetaCatClient, MCError
 
 from metacat.ui.cli import CLI, CLICommand, InvalidArguments
-from .common import load_text, load_json, load_file_list
+from .common import load_text, load_json, load_file_list, exit_code_from_exception
 
 class ListDatasetFilesCommand(CLICommand):
     
@@ -206,10 +206,7 @@ class CreateDatasetCommand(CLICommand):
             )
 
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         else:
             if "-j" in opts or "--json" in opts:
                 print(json.dumps(out, indent=4, sort_keys=True))
@@ -256,10 +253,7 @@ class UpdateDatasetCommand(CLICommand):
                 frozen=frozen, monotonic=monotonic, 
                 mode=mode, description=desc)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         else:
             if "-j" in opts or "--json" in opts:
                 print(json.dumps(response, indent=4, sort_keys=True))
@@ -340,10 +334,7 @@ class AddFilesCommand(CLICommand):
         try:
             nadded = client.add_files(dataset, file_list=files, query=query)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         else:
             print("Added", nadded, "files")
 
@@ -422,10 +413,7 @@ class RemoveFilesCommand(CLICommand):
         try:
             nremoved = client.remove_files(dataset, file_list=files, query=query)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         else:
             print("Removed", nremoved, "files")
 
@@ -440,10 +428,7 @@ class RemoveDatasetCommand(CLICommand):
         try:
             nremoved = client.remove_dataset(dataset)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
 DatasetCLI = CLI(
     "create",       CreateDatasetCommand(),

--- a/metacat/ui/metacat_dataset.py
+++ b/metacat/ui/metacat_dataset.py
@@ -107,7 +107,7 @@ class ShowDatasetCommand(CLICommand):
         info = client.get_dataset(args[0])
         if info is None:
             print("Dataset not found")
-            sys.exit(1)
+            sys.exit(11)
         if "-p" in opts or "--pprint" in opts:
             pprint.pprint(info)
         elif "-j" in opts or "--json" in opts:
@@ -207,8 +207,9 @@ class CreateDatasetCommand(CLICommand):
 
         except MCError as e:
             print(e)
-
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         else:
             if "-j" in opts or "--json" in opts:
                 print(json.dumps(out, indent=4, sort_keys=True))
@@ -256,7 +257,9 @@ class UpdateDatasetCommand(CLICommand):
                 mode=mode, description=desc)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         else:
             if "-j" in opts or "--json" in opts:
                 print(json.dumps(response, indent=4, sort_keys=True))
@@ -338,7 +341,9 @@ class AddFilesCommand(CLICommand):
             nadded = client.add_files(dataset, file_list=files, query=query)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         else:
             print("Added", nadded, "files")
 
@@ -418,7 +423,9 @@ class RemoveFilesCommand(CLICommand):
             nremoved = client.remove_files(dataset, file_list=files, query=query)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         else:
             print("Removed", nremoved, "files")
 
@@ -434,7 +441,9 @@ class RemoveDatasetCommand(CLICommand):
             nremoved = client.remove_dataset(dataset)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
 DatasetCLI = CLI(
     "create",       CreateDatasetCommand(),

--- a/metacat/ui/metacat_file.py
+++ b/metacat/ui/metacat_file.py
@@ -4,7 +4,7 @@ from metacat.webapi import MetaCatClient, MCWebAPIError, MCInvalidMetadataError,
 from metacat.ui.cli import CLI, CLICommand, InvalidOptions, InvalidArguments
 from metacat.util import ObjectSpec, undid
 from datetime import timezone, datetime
-from .common import load_text, load_file_list, load_json
+from .common import load_text, load_file_list, load_json, exit_code_from_exception
 
 class DeclareSampleCommand(CLICommand):
     Usage = """-- print sample input for declare-many command
@@ -236,10 +236,7 @@ class DeclareManyCommand(CLICommand):
         try:
             response = client.declare_files(f"{dataset_namespace}:{dataset_name}", files, dry_run = "-d" in opts, as_required=as_required)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
         if "-j" in opts or "--json" in opts:
             print(json.dumps(response, indent=4, sort_keys=True))
@@ -270,10 +267,7 @@ class DatasetsCommand(CLICommand):
         try:
             data = client.get_file(did=did, fid=fid, with_provenance=False, with_metadata=False, with_datasets=True)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
         if data is None:
             print("File not found", file=sys.stderr)
@@ -308,10 +302,7 @@ class FileIDCommand(CLICommand):
             data = client.get_file(did=did, namespace=namespace, name=name, with_provenance=False, with_metadata=False,
                                with_datasets=False)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         if data is None:
             print("File not found", file=sys.stderr)
             sys.exit(7)
@@ -340,10 +331,7 @@ class RetireCommand(CLICommand):
         try:
             data = client.retire_file(did=did, namespace=namespace, name=name, retire=do_retire)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
         if data is None:
             print("File not found", file=sys.stderr)
             sys.exit(7)
@@ -364,10 +352,7 @@ class NameCommand(CLICommand):
         try:
             data = client.get_file(fid=fid, with_provenance=False, with_metadata=False, with_datasets=False)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
         if data is None:
             print("File not found", file=sys.stderr)
@@ -423,10 +408,7 @@ class ShowCommand(CLICommand):
                         with_provenance=include_provenance, with_metadata=include_meta,
                         with_datasets=include_datasets)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
         if data is None:
             print("File not found", file=sys.stderr)
@@ -542,10 +524,7 @@ class UpdateMetaCommand(CLICommand):
         try:
             response = client.update_file_meta(meta, files=file_list, mode=mode, namespace=namespace)
         except MCError as e:
-            print(e)
-            error_code = (hash(str(e)) % 89) + 32
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(e))
 
 class UpdateCommand(CLICommand):
     

--- a/metacat/ui/metacat_file.py
+++ b/metacat/ui/metacat_file.py
@@ -237,7 +237,9 @@ class DeclareManyCommand(CLICommand):
             response = client.declare_files(f"{dataset_namespace}:{dataset_name}", files, dry_run = "-d" in opts, as_required=as_required)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
         if "-j" in opts or "--json" in opts:
             print(json.dumps(response, indent=4, sort_keys=True))
@@ -269,11 +271,13 @@ class DatasetsCommand(CLICommand):
             data = client.get_file(did=did, fid=fid, with_provenance=False, with_metadata=False, with_datasets=True)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
         if data is None:
             print("File not found", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(7)
         datasets = sorted(data.get("datasets", []), key = lambda ds: (ds["namespace"], ds["name"]))
         if "-j" in opts:
             print(json.dumps(datasets, indent=4, sort_keys=True))
@@ -305,10 +309,12 @@ class FileIDCommand(CLICommand):
                                with_datasets=False)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         if data is None:
             print("File not found", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(7)
 
         print(data["fid"])
 
@@ -335,10 +341,12 @@ class RetireCommand(CLICommand):
             data = client.retire_file(did=did, namespace=namespace, name=name, retire=do_retire)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         if data is None:
             print("File not found", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(7)
 
 class NameCommand(CLICommand):
 
@@ -357,11 +365,13 @@ class NameCommand(CLICommand):
             data = client.get_file(fid=fid, with_provenance=False, with_metadata=False, with_datasets=False)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
         if data is None:
             print("File not found", file=sys.stderr)
-            sys.exit(1)
+            sys.exit(7)
 
         namespace, name = data["namespace"], data["name"]
         if "-j" in opts or "--json" in opts:
@@ -414,11 +424,13 @@ class ShowCommand(CLICommand):
                         with_datasets=include_datasets)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
         if data is None:
-            print("file not found", file=sys.stderr)
-            sys.exit(1)
+            print("File not found", file=sys.stderr)
+            sys.exit(7)
         
         if include_provenance:
             parents = data.get("parents", [])
@@ -531,7 +543,9 @@ class UpdateMetaCommand(CLICommand):
             response = client.update_file_meta(meta, files=file_list, mode=mode, namespace=namespace)
         except MCError as e:
             print(e)
-            sys.exit(1)
+            error_code = (hash(str(e)) % 89) + 32
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
 
 class UpdateCommand(CLICommand):
     
@@ -607,7 +621,7 @@ class UpdateCommand(CLICommand):
             invalid_names = [k for k in metadata_update if '.' not in k]
             if invalid_names:
                 print("Invalid metadata key(s):", ", ".join(invalid_names), file=sys.stderr)
-                sys.exit(1)
+                sys.exit(13)
             update_args["metadata"] = metadata_update
 
         parents_specs = opts.get("-p") or opts.get("--parents")
@@ -691,7 +705,7 @@ class AddCommand(CLICommand):
     
     def __call__(self, command, client, opts, args):
         print('Use "metacat dataset add..." instead')
-        sys.exit(1)
+        sys.exit(14)
 
         # backward compatibility
         opts["-f"] = (
@@ -774,7 +788,7 @@ class MoveCommand(CLICommand):
                 print("Number of errors:  ", len(errors))
         print("Files moved:       ", nmoved)
         if errors:
-            sys.exit(1)
+            sys.exit(19)
 
 FileCLI = CLI(
     "declare",  DeclareSingleCommand(),

--- a/metacat/ui/metacat_named_query.py
+++ b/metacat/ui/metacat_named_query.py
@@ -51,7 +51,7 @@ class ShowNamedQueryCommand(CLICommand):
         query = client.get_named_query(namespace, name)
         if query is None:
             print("Not found")
-            sys.exit(1)
+            sys.exit(7)
         if as_json:
             print(json.dumps(query, indent=2, sort_keys=True))
         elif not verbose:

--- a/metacat/ui/metacat_ui.py
+++ b/metacat/ui/metacat_ui.py
@@ -14,6 +14,7 @@ from .metacat_report import ReportMetadataCommand
 from .metacat_category import CategoryCLI
 from .metacat_named_query import NamedQueriesCLI
 from metacat.util import validate_metadata
+from .common import exit_code_from_exception
 
 import warnings
 warnings.simplefilter("ignore")
@@ -199,13 +200,12 @@ class ValidateMetadataCommand(CLICommand):
                 for name_error in errors:
                     if name_error:
                         print("%-40s: %s" % (name_error[0], " ".join(name_error[1:])))
-            error_code = (hash(errors) % 126) + 1
-            print("trying to exit: ", error_code)
-            sys.exit(error_code)
+            sys.exit(exit_code_from_exception(errors))
         else:
             sys.exit(0)
 
 Commands = ["admin","auth","dataset","query","namespace","file","report"]
+
 
 def main():
 
@@ -238,11 +238,7 @@ def main():
        print("Invalid Metadata", file=sys.stderr)
        sys.exit(13)
     except Exception as e:
-        msg = f"Exception: {type(e)} {e.args}"
-        print(msg, file=sys.stderr)
-        error_code = (ord(msg[0])+len(msg)) % 89 + 32
-        print("trying to exit: ", error_code)
-        sys.exit(error_code)
+        sys.exit(exit_code_from_exception(e))
 
 if __name__ == "__main__":
     print("debug one")

--- a/metacat/ui/metacat_ui.py
+++ b/metacat/ui/metacat_ui.py
@@ -1,5 +1,5 @@
 from metacat.webapi import MCWebAPIError, MetaCatClient, MCError, AuthenticationError
-from metacat.webapi.webapi import NotFoundError, AlreadyExistsError, PermissionDeniedError, InvalidMetadataError
+from metacat.webapi.webapi import NotFoundError, AlreadyExistsError, PermissionDeniedError, InvalidMetadataError, BadRequestError
 from metacat import Version
 import sys, getopt, os, json
 from .cli import CLI, CLICommand
@@ -207,6 +207,7 @@ class ValidateMetadataCommand(CLICommand):
 Commands = ["admin","auth","dataset","query","namespace","file","report"]
 
 
+
 def main():
 
     cli = MetaCatCLI(
@@ -225,22 +226,24 @@ def main():
     )
     try:
         cli.run(sys.argv, argv0="metacat")
+    except BadRequestError as e:
+       print(f"Bad Request error: {e.Message=}")
+       sys.exit(18)
     except NotFoundError as e:
-       print("File not found on server", file=sys.stderr)
+       print(f"File not found on server {e.Message}", file=sys.stderr)
        sys.exit(12)
     except AlreadyExistsError as e:
-       print("Already exists on server", file=sys.stderr)
+       print(f"Already exists on server {e.Message}", file=sys.stderr)
        sys.exit(16)
     except PermissionDeniedError as e:
-       print("Permission Denied by server", file=sys.stderr)
+       print(f"Permission Denied by server {e.Message}", file=sys.stderr)
        sys.exit(17)
     except InvalidMetadataError as e:
-       print("Invalid Metadata", file=sys.stderr)
+       print(f"Invalid MetadataError : {e.Message} {str(e)}", file=sys.stderr)
        sys.exit(13)
     except Exception as e:
-        sys.exit(exit_code_from_exception(e))
+       sys.exit(exit_code_from_exception(e))
 
 if __name__ == "__main__":
-    print("debug one")
     main()
     

--- a/metacat/ui/metacat_ui.py
+++ b/metacat/ui/metacat_ui.py
@@ -1,4 +1,5 @@
 from metacat.webapi import MCWebAPIError, MetaCatClient, MCError, AuthenticationError
+from metacat.webapi.webapi import NotFoundError, AlreadyExistsError, PermissionDeniedError, InvalidMetadataError
 from metacat import Version
 import sys, getopt, os, json
 from .cli import CLI, CLICommand
@@ -224,10 +225,22 @@ def main():
     )
     try:
         cli.run(sys.argv, argv0="metacat")
-    except (AuthenticationError, MCError) as e:
-        msg = str(e)
+    except NotFoundError as e:
+       print("File not found on server", file=sys.stderr)
+       sys.exit(12)
+    except AlreadyExistsError as e:
+       print("Already exists on server", file=sys.stderr)
+       sys.exit(16)
+    except PermissionDeniedError as e:
+       print("Permission Denied by server", file=sys.stderr)
+       sys.exit(17)
+    except InvalidMetadataError as e:
+       print("Invalid Metadata", file=sys.stderr)
+       sys.exit(13)
+    except Exception as e:
+        msg = f"Exception: {type(e)} {e.args}"
         print(msg, file=sys.stderr)
-        error_code = (hash(msg) % 89) + 32
+        error_code = (ord(msg[0])+len(msg)) % 89 + 32
         print("trying to exit: ", error_code)
         sys.exit(error_code)
 

--- a/metacat/ui/metacat_ui.py
+++ b/metacat/ui/metacat_ui.py
@@ -70,7 +70,7 @@ class MetaCatCLI(CLI):
     
             if not server_url:
                 print("Server address must be specified either using -s option or using environment variable METACAT_SERVER_URL", file=sys.stderr)
-                sys.exit(2)
+                sys.exit(15)
 
             auth_server_url = opts.get("-a") or os.environ.get("METACAT_AUTH_SERVER_URL")
             if not auth_server_url:
@@ -132,7 +132,7 @@ class ValidateMetadataCommand(CLICommand):
             dataset = client.get_dataset(dataset_did)
             if dataset is None:
                 print(f"Dataset {dataset_did} not found", file=sys.stderr)
-                sys.exit(1)
+                sys.exit(11)
 
         if self.Categories is None:
             categories = self.Categories = {c["path"]:c for c in client.list_categories()}
@@ -198,7 +198,9 @@ class ValidateMetadataCommand(CLICommand):
                 for name_error in errors:
                     if name_error:
                         print("%-40s: %s" % (name_error[0], " ".join(name_error[1:])))
-            sys.exit(1)
+            error_code = (hash(errors) % 126) + 1
+            print("trying to exit: ", error_code)
+            sys.exit(error_code)
         else:
             sys.exit(0)
 
@@ -223,9 +225,13 @@ def main():
     try:
         cli.run(sys.argv, argv0="metacat")
     except (AuthenticationError, MCError) as e:
-        print(e, file=sys.stderr)
-        sys.exit(1)
+        msg = str(e)
+        print(msg, file=sys.stderr)
+        error_code = (hash(msg) % 89) + 32
+        print("trying to exit: ", error_code)
+        sys.exit(error_code)
 
 if __name__ == "__main__":
+    print("debug one")
     main()
     

--- a/metacat/ui/mql.py
+++ b/metacat/ui/mql.py
@@ -66,7 +66,7 @@ from metacat.filters import standard_filters as filters
 
 if not sys.argv[1:] or sys.argv[1] in ("help", "--help", "-?"):
     print(Usage)
-    sys.exit(2)
+    sys.exit(1)
 
 cmd = sys.argv[1]
 opts, args = getopt(sys.argv[2:], "dc:os")

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -277,10 +277,10 @@ def test_metacat_dataset_update(auth, tst_ds):
 
 def test_metacat_dataset_remove(auth, tst_ds):
     tst_ds2 = tst_ds + "_super"
-    with os.popen(f"metacat dataset remove {tst_ds2}", "r") as fin:
+    with os.popen(f"metacat dataset remove {tst_ds2} 2>&1", "r") as fin:
         data = fin.read()
     assert data.strip() == ""
-    with os.popen(f"metacat dataset remove {tst_ds2}", "r") as fin:
+    with os.popen(f"metacat dataset remove {tst_ds2} 2>&1", "r") as fin:
         data = fin.read()
     assert data.find("not found") >= 0
 

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -257,12 +257,21 @@ def test_metacat_dataset_add_files(auth, tst_ds):
         data = fin.read()
     assert data.find("Added 2 files") >= 0
 
+def check_result(fin, fn, expected):
+    st = fin.close()
+    if st != None:
+        rc = os.waitstatus_to_exitcode(st)
+        #with open("results.txt", "a") as fout:
+        #    print(f"{fn} result: {rc}, expected {expected}", file=fout)
+        print(f"{fn} exit code result: {rc}, expected {expected}")
+        assert(rc == expected)
 
 def test_metacat_dataset_update_fail(auth, tst_ds):
     md = '{"foo": "bar"}'
     with os.popen(f"metacat dataset update -j -m '{md}' {tst_ds} 2>&1", "r") as fin:
         data = fin.read()
         # check output
+        check_result(fin, "update_fail", 67)
     assert data.find("Metadata parameter without a category") >= 0
 
 
@@ -282,6 +291,7 @@ def test_metacat_dataset_remove(auth, tst_ds):
     assert data.strip() == ""
     with os.popen(f"metacat dataset remove {tst_ds2} 2>&1", "r") as fin:
         data = fin.read()
+        check_result(fin, "dataset_remove", 12)
     assert data.find("not found") >= 0
 
 

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -12,6 +12,15 @@ import time
 
 from env import env, token, auth, start_ds, tst_ds, tst_file_md_list
 
+def check_result(fin, fn, expected):
+    st = fin.close()
+    if st != None:
+        rc = os.waitstatus_to_exitcode(st)
+        #with open("results.txt", "a") as fout:
+        #    print(f"{fn} result: {rc}, expected {expected}", file=fout)
+        print(f"{fn} exit code result: {rc}, expected {expected}")
+        assert(rc == expected)
+
 
 # need tests for at least:
 
@@ -110,6 +119,7 @@ def test_initial_namespace_create(auth):
     os.system(f'metacat namespace create {os.environ["USER"]}')
     with os.popen(f'metacat namespace create {os.environ["USER"]} 2>&1', "r") as fin:
         data = fin.read()
+        check_result(fin, "namespace_create", 16)
     assert data.find("exists") > 0
 
 # jumping some file delcaration tests first, so we then have some files
@@ -256,15 +266,6 @@ def test_metacat_dataset_add_files(auth, tst_ds):
     with os.popen(f"metacat dataset add-files --query '{query}' {tst_ds} ", "r") as fin:
         data = fin.read()
     assert data.find("Added 2 files") >= 0
-
-def check_result(fin, fn, expected):
-    st = fin.close()
-    if st != None:
-        rc = os.waitstatus_to_exitcode(st)
-        #with open("results.txt", "a") as fout:
-        #    print(f"{fn} result: {rc}, expected {expected}", file=fout)
-        print(f"{fn} exit code result: {rc}, expected {expected}")
-        assert(rc == expected)
 
 def test_metacat_dataset_update_fail(auth, tst_ds):
     md = '{"foo": "bar"}'
@@ -471,6 +472,7 @@ def test_metacat_validate_bad(auth, tst_file_md_list, tst_ds):
         json.dump(md, mdf)
     with os.popen(f"metacat validate mdf1 2>&1", "r") as fin:
         data = fin.read()
+        check_result(fin, "validate_bad", 81)
     os.unlink("mdf1")
     assert data.find("wrong") >= 0
 


### PR DESCRIPTION
This is from a DUNE request for situations where code/logs  have  the exit code of the metacat command line but apparently not the actual error messages.   It attempts to give all different errors a separate exit code,  and a table of common ones has been added to the documentation. 