### PR TITLE
Fix limited/strided/skipped duplicating or crashing on list and None inputs

### DIFF
--- a/metacat/util/generators.py
+++ b/metacat/util/generators.py
@@ -31,8 +31,10 @@ def unique(iterable, key=None):
 def limited(iterable, n):
     if n is None:
         yield from iterable
+        return
     if isinstance(iterable, (list, tuple)):
         yield from iterable[:n]
+        return
     for f in iterable:
         if n is None:
             yield f
@@ -46,6 +48,7 @@ def limited(iterable, n):
 def strided(iterable, n, i=0):
     if n is None:
         yield from iterable
+        return
     for j, f in enumerate(iterable):
         if j%n == i:
             yield f
@@ -53,8 +56,10 @@ def strided(iterable, n, i=0):
 def skipped(iterable, n):
     if n is None:
         yield from iterable
+        return
     if isinstance(iterable, (list, tuple)):
         yield from iterable[n:]
+        return
     for f in iterable:
         if n > 0:
             n -= 1

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,31 @@
+from metacat.util.generators import limited, strided, skipped
+
+
+def test_limited_list_does_not_double_yield():
+    assert list(limited([1, 2, 3, 4, 5], 3)) == [1, 2, 3]
+    assert list(limited((10, 20, 30), 2)) == [10, 20]
+
+
+def test_limited_none_returns_each_once():
+    assert list(limited([1, 2, 3], None)) == [1, 2, 3]
+
+
+def test_limited_generator_unchanged():
+    assert list(limited((x for x in [1, 2, 3, 4, 5]), 3)) == [1, 2, 3]
+    assert list(limited((x for x in [1, 2, 3]), None)) == [1, 2, 3]
+
+
+def test_strided_none_yields_all():
+    assert list(strided([0, 1, 2, 3], None)) == [0, 1, 2, 3]
+
+
+def test_strided_step_unchanged():
+    assert list(strided([0, 1, 2, 3, 4, 5], 2)) == [0, 2, 4]
+
+
+def test_skipped_list_does_not_double_yield():
+    assert list(skipped([1, 2, 3, 4, 5], 2)) == [3, 4, 5]
+
+
+def test_skipped_none_yields_all():
+    assert list(skipped([1, 2, 3], None)) == [1, 2, 3]


### PR DESCRIPTION
I was reading through metacat/util/generators.py and noticed that limited, strided and skipped fall through their early-exit branches.

Each has an `if n is None: yield from iterable` short-circuit, and limited/skipped also have an `if isinstance(iterable, (list, tuple)): yield from iterable[...]` fast path, but none of those branches returns. So control keeps going into the per-item loop below and yields the data a second time, or reaches the loop with n still None and raises.

A few concrete cases against the current code:

    limited([1,2,3,4,5], 3) -> [1,2,3,1,2,3]        # should be [1,2,3]
    limited([1,2,3], None)  -> [1,2,3,1,2,3,1,2,3]  # should be [1,2,3]
    skipped([1,2,3,4,5], 2) -> [3,4,5,3,4,5]        # should be [3,4,5]
    strided([0,1,2,3], None) -> TypeError (int % None)
    skipped([1,2,3], None)   -> TypeError (None > 0)

Generators happen to work because the first `yield from` exhausts them, which is probably why this went unnoticed, but DBFileSet can wrap a plain list (files=[...]) and then limit()/skip()/stride() hit the list path.

The fix is just to return after each early branch. Generator behavior with a positive n is unchanged. I added a small tests/test_generators.py covering the list, tuple, None and generator cases.

Thanks for taking a look.
