### PR TITLE
Categories API and required categories

### DIFF
--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -195,7 +195,7 @@ To see available MetaCat authentication tokens:
 
 Export token to a file or to stdout
     
-    .. code-block:: shell
+.. code-block:: shell
     
     metacat auth export [-o|--out <token file>] [<token id>|<server url>]
 	
@@ -227,23 +227,6 @@ To list existing namespaces:
         -d                          - exclude namespaces owned by the user via a role
         -r|--role <role>            - list namespaces owned by the role
 
-
-Parameter Categories
---------------------
-
-To list existing parameter categories:
-
-.. code-block:: shell
-
-        $ metacat category list [options] [<root category>]
-                  -j|--json           - print as JSON
-
-To get particular category information:
-
-.. code-block:: shell
-
-        $ metacat category show [options] <category>
-                  -j|--json           - print as JSON
 
 Datasets
 --------
@@ -805,27 +788,39 @@ quietly exit with 0 or 1 status.
 Metadata Categories
 -------------------
 
+Metadata categories define the structure and constraints for metadata parameters. 
+They are used to validate metadata values when files are declared or updated.
+
+MetaCat metadata has the format ``<category>.parameter>``.
+
+Listing categories
+...................
+
 Existing parameter categories can be listed using:
 
 .. code-block:: shell
 
-    $ metacat category list
-    .
-    DUNE
-    DUNE_MC
-    ivm
-    ...
-    
-    
+    $ metacat category list [options] [<root category>]
+              -j|--json           - print as JSON
+
+If a root category is specified, only categories under that path will be listed.
+
 Information about an individual category can be printed using:
 
-.. code-block::
+.. code-block:: shell
+
+    $ metacat category show [options] <category>
+              -j|--json           - print as JSON
+
+The output shows:
+
+.. code-block:: none
 
     $ metacat category show ivm
     Path:             ivm
     Description:      ivm test category
     Owner user:       ivm
-    Owner role:       
+    Owner role:
     Creator:          ivm
     Created at:       2022-09-27 10:51:19 UTC
     Restricted:       no
@@ -836,6 +831,92 @@ Information about an individual category can be printed using:
       pi                                            float [3.0 - 4.0]
       word                                           text ~ '[A-Z].*'
 
+Creating a category
+...................
+
+To create a new parameter category with constraints:
+
+.. code-block:: shell
+
+    $ metacat category create [options] <category>
+              -d|--description <description>
+              -r|--restricted           - make the category restricted (only defined parameters allowed)
+              -o|--owner <owner_role>   - owner role (default: current user)
+              -p|--parameters <file|json>  - parameter definitions as JSON file or inline JSON
+              -j|--json                 - print as JSON
+
+Parameter definitions define the constraints for each parameter. Each parameter can have:
+
+- ``type``: int, float, text, boolean, dict, list, int[], float[], text[], boolean[], or any
+- ``values``: list of allowed values (enum)
+- ``min``: minimum value (for numeric and text)
+- ``max``: maximum value (for numeric and text)
+- ``pattern``: regex pattern for text values
+.. - ``required``: boolean, whether the parameter is required
+
+Example:
+
+.. code-block:: shell
+
+    $ metacat category create -d "Test category" -r \
+        -p '{"run_number": {"type": "int", "min": 1, "max": 1000}, "status": {"type": "text", "values": ["good", "bad"]}}' \
+        test_category
+
+Only admins can create categories.
+
+Updating a category
+...........
+
+To update an existing category:
+
+.. code-block:: shell
+
+    $ metacat category update [options] <category>
+              -d|--description <description>
+              -r|--restricted (true|false)
+              -o|--owner <owner_role>
+              -p|--parameters <file|json>  - parameter definitions (merged by default)
+              -m|--mode (update|replace)    - mode for updating definitions (default: update)
+              -j|--json                 - print as JSON
+
+The ``-m`` option controls how parameter definitions are updated:
+
+- ``update`` (default): Merge new definitions with existing ones (keeps undefined parameters)
+- ``replace``: Replace the entire definitions dictionary
+
+Example (add new parameter definitions while keeping existing ones):
+
+.. code-block:: shell
+
+    $ metacat category update -p '{"new_param": {"type": "int"}}' test_category
+
+Only admins can update categories.
+
+Removing a category
+...........
+
+To remove a category:
+
+.. code-block:: shell
+
+    $ metacat category remove <category>
+
+Only admins can remove categories.
+
+Metadata validation
+...........
+
+MetaCat enforces the category parameter definitions when files are declared or updated.
+
+MetaCat checks that metadata using parameters from that category must follow the defined constraints. 
+For example, if a category defines ``run_number`` as an integer between 1 and 1000, attempting to declare 
+a file with ``run_number`` outside that range will result in a validation error.
+
+When a category is marked as ``restricted``, only parameters in the category's definitions are allowed. 
+Attempting to add a metadata parameter not in the definitions will result in a validation error.
+
+When a definition is marked as ``required``, that parameter must be present in the metadata. 
+Attempting to add metadata without required parameters will result in a validation error.
 
 
 Query

--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -839,11 +839,12 @@ To create a new parameter category with constraints:
 .. code-block:: shell
 
     $ metacat category create [options] <category>
-              -d|--description <description>
-              -r|--restricted           - make the category restricted (only defined parameters allowed)
-              -o|--owner <owner_role>   - owner role (default: current user)
-              -p|--parameters <file|json>  - parameter definitions as JSON file or inline JSON
-              -j|--json                 - print as JSON
+              -d <description>                             - description of category
+              -r <True|False>                              - whether a category is restricted (cannot add extra fields to metadata), default False
+              -n <True|False>                              - whether a category is required (required field(s) must be present in metadata), default False
+              -o <owner>                                   - owner of category, default current user
+              -p <file|json>                               - parameter definitions as JSON file or inline JSON
+              -j                                           - print category information as JSON
 
 Parameter definitions define the constraints for each parameter. Each parameter can have:
 
@@ -852,7 +853,7 @@ Parameter definitions define the constraints for each parameter. Each parameter 
 - ``min``: minimum value (for numeric and text)
 - ``max``: maximum value (for numeric and text)
 - ``pattern``: regex pattern for text values
-.. - ``required``: boolean, whether the parameter is required
+- ``required``: boolean, whether the parameter is required
 
 Example:
 
@@ -865,19 +866,21 @@ Example:
 Only admins can create categories.
 
 Updating a category
-...........
+...................
 
 To update an existing category:
 
 .. code-block:: shell
 
     $ metacat category update [options] <category>
-              -d|--description <description>
-              -r|--restricted (true|false)
-              -o|--owner <owner_role>
-              -p|--parameters <file|json>  - parameter definitions (merged by default)
-              -m|--mode (update|replace)    - mode for updating definitions (default: update)
-              -j|--json                 - print as JSON
+                -d <description>                            - description of category
+                -r <True|False>                             - whether a category is restricted (cannot add extra fields to metadata), default False
+                -n <True|False>                             - whether a category is required (required field(s) must be present in metadata), default False
+                -o <owner>                                  - owner of category, default current user
+                -p <file|json>                              - parameter definitions as JSON file or inline JSON
+                -m <update|replace>                         - mode for updating definitions, default update
+                -j                                          - print category information as JSON
+
 
 The ``-m`` option controls how parameter definitions are updated:
 
@@ -893,7 +896,7 @@ Example (add new parameter definitions while keeping existing ones):
 Only admins can update categories.
 
 Removing a category
-...........
+...................
 
 To remove a category:
 
@@ -904,7 +907,7 @@ To remove a category:
 Only admins can remove categories.
 
 Metadata validation
-...........
+...................
 
 MetaCat enforces the category parameter definitions when files are declared or updated.
 
@@ -915,8 +918,13 @@ a file with ``run_number`` outside that range will result in a validation error.
 When a category is marked as ``restricted``, only parameters in the category's definitions are allowed. 
 Attempting to add a metadata parameter not in the definitions will result in a validation error.
 
-When a definition is marked as ``required``, that parameter must be present in the metadata. 
-Attempting to add metadata without required parameters will result in a validation error.
+When a category is marked as ``required``, that category must be present in the metadata.
+Attempting to add metadata without a required category will result in a validation error.
+A category can only be required if at least one of its parameters are required.
+
+When a definition is marked as ``required``, that parameter must be present in the metadata if the 
+category is present or marked as required. Attempting to add metadata without required parameters will 
+result in a validation error.
 
 
 Query

--- a/metacat/db/param_category.py
+++ b/metacat/db/param_category.py
@@ -6,7 +6,7 @@ from metacat.util import epoch, validate_metadata, fetch_generator
 class DBParamCategory(DBObject):
 
     Table = "parameter_categories"
-    ColumnsText = "path,owner_user,owner_role,description,restricted,definitions,creator,created_timestamp"
+    ColumnsText = "path,owner_user,owner_role,restricted,description,creator,created_timestamp,definitions,required"
     Columns = ColumnsText.split(",")
     PK = ["path"]
 
@@ -27,13 +27,14 @@ class DBParamCategory(DBObject):
     Types =  ('int','float','text','boolean',
                 'int[]','float[]','text[]','boolean[]','dict', 'list', 'any')
 
-    def __init__(self, db, path, restricted=False, owner_role=None, owner_user=None, creator=None, definitions={}, description="", created_timestamp=None):
+    def __init__(self, db, path, restricted=False, required=False, owner_role=None, owner_user=None, creator=None, definitions={}, description="", created_timestamp=None):
         self.Path = path
         self.DB = db
         self.OwnerUser = owner_user
         self.OwnerRole = owner_role
         self.Description = description
         self.Restricted = restricted
+        self.Required = required
         self.Definitions = definitions         
         self.Creator = creator 
         self.CreatedTimestamp = created_timestamp
@@ -56,6 +57,7 @@ class DBParamCategory(DBObject):
             owner_role = self.OwnerRole,
             description = self.Description,
             restricted = self.Restricted,
+            required = self.Required,
             definitions = self.Definitions,
             creator = self.Creator,
             created_timestamp = epoch(self.CreatedTimestamp)
@@ -95,10 +97,10 @@ class DBParamCategory(DBObject):
         transaction.execute(f"""
             update parameter_categories
                 set owner_user=%(owner_user)s, owner_role=%(owner_role)s, restricted=%(restricted)s, 
-                    definitions=%(defs)s, description=%(description)s
+                    required=%(required)s, definitions=%(defs)s, description=%(description)s
                 where path = %(path)s
             """,
-            dict(path=self.Path, owner_user=self.OwnerUser, owner_role=self.OwnerRole, restricted=self.Restricted, defs=defs,
+            dict(path=self.Path, owner_user=self.OwnerUser, owner_role=self.OwnerRole, restricted=self.Restricted, required=self.Required, defs=defs,
                     description=self.Description, creator=self.Creator))
         return self
 
@@ -107,12 +109,12 @@ class DBParamCategory(DBObject):
         defs = json.dumps(self.Definitions)
         columns = self.columns(exclude="created_timestamp")
         transaction.execute(f"""
-            insert into parameter_categories({columns}) 
-                values(%(path)s, %(owner_user)s, %(owner_role)s, %(description)s, %(restricted)s, %(defs)s, %(creator)s)
+            insert into parameter_categories({columns})
+                values(%(path)s, %(owner_user)s, %(owner_role)s, %(restricted)s, %(description)s, %(creator)s, %(defs)s, %(required)s)
                 returning created_timestamp
             """,
-            dict(path=self.Path, owner_user=self.OwnerUser, owner_role=self.OwnerRole, restricted=self.Restricted, defs=defs,
-                    description=self.Description, creator=self.Creator)
+            dict(path=self.Path, owner_user=self.OwnerUser, owner_role=self.OwnerRole, restricted=self.Restricted,
+                    description=self.Description, creator=self.Creator, defs=defs, required=self.Required)
         )
         self.CreatedTimestamp = transaction.fetchone()[0]
         return self
@@ -126,9 +128,9 @@ class DBParamCategory(DBObject):
     @staticmethod
     def from_tuple(db, tup):
         if tup is None: return None
-        path, owner_user, owner_role, description, restricted, definitions, creator, created_timestamp = tup
-        return DBParamCategory(db, path, owner_user=owner_user, owner_role=owner_role, description=description, 
-                restricted=restricted, definitions=definitions, creator=creator, created_timestamp=created_timestamp)
+        path, owner_user, owner_role, restricted, description, creator, created_timestamp, definitions, required = tup
+        return DBParamCategory(db, path, owner_user=owner_user, owner_role=owner_role, restricted=restricted,
+                description=description, definitions=definitions, creator=creator, created_timestamp=created_timestamp, required=required)
 
     @staticmethod
     def get_many(db, paths):
@@ -172,7 +174,6 @@ class DBParamCategory(DBObject):
             return False, errors[0][1]
         else:
             return True, "valid"
-        return True, "valid"
     
     @staticmethod
     def validate_metadata_bulk(db, items):
@@ -185,7 +186,17 @@ class DBParamCategory(DBObject):
         # returns list of tuples:
         #     (item, {"param name":"error", ...})
         #
-        
+
+        # Collect all required parameters from required categories
+        required_params = {}  # path -> set of required param names
+        all_categories = {c.Path: c for c in DBParamCategory.list(db)}
+        for path, category in all_categories.items():
+            if category and category.Required and category.Definitions:
+                for pname, definition in category.Definitions.items():
+                    if definition.get("required"):
+                        required_params.setdefault(path, set()).add(pname)
+
+        # Collect all category paths from metadata
         category_paths = set()
         for item in items:
             meta = item if isinstance(item, dict) else item.metadata()
@@ -200,10 +211,18 @@ class DBParamCategory(DBObject):
         for index, item in enumerate(items):
             meta = item if isinstance(item, dict) else item.metadata()
             item_errors = []
+
+            # Check required params for required categories
+            for path, required_set in required_params.items():
+                for pname in required_set:
+                    param_key = path + "." + pname
+                    if param_key not in meta:
+                        item_errors.append({"name": param_key, "reason": f"required parameter '{pname}' is missing from category '{path}'", "value": None})
+
             for name, value in meta.items():
                 if "." in name:
                     path, vname = name.rsplit(".", 1)
-                    category = categories[path]
+                    category = categories.get(path)
                     if category is not None:
                         ok, error = category.validate_parameter(vname, value)
                         if not ok:

--- a/metacat/db/param_category.py
+++ b/metacat/db/param_category.py
@@ -116,6 +116,12 @@ class DBParamCategory(DBObject):
         )
         self.CreatedTimestamp = transaction.fetchone()[0]
         return self
+
+    @transactioned
+    def delete(self, transaction=None):
+        transaction.execute("""
+            delete from parameter_categories where path = %s;
+        """, (self.Path,))
     
     @staticmethod
     def from_tuple(db, tup):

--- a/metacat/db/schema.sql
+++ b/metacat/db/schema.sql
@@ -173,7 +173,8 @@ create table parameter_categories
     description         text,
     creator             text references users(username),
     created_timestamp   timestamp with time zone     default now(),
-    definitions         jsonb
+    definitions         jsonb,
+    required    boolean default 'false',
 );
 
 grant select, insert, update, delete, truncate, references, trigger on all tables in schema metacat to dm_admin;

--- a/metacat/ui/metacat_category.py
+++ b/metacat/ui/metacat_category.py
@@ -4,6 +4,35 @@ from urllib.parse import quote_plus, unquote_plus
 from metacat.util import to_bytes, to_str
 from metacat.webapi import MetaCatClient, MCError
 from metacat.ui.cli import CLI, CLICommand, InvalidOptions, InvalidArguments
+from metacat.ui.common import load_json
+
+def print_category(data):
+    print("Path:            ", data["path"])
+    print("Description:     ", data.get("description") or "")
+    print("Owner user:      ", data.get("owner_user", "") or "")
+    print("Owner role:      ", data.get("owner_role", "") or "")
+    print("Creator:         ", data.get("creator", ""))
+    ct = data.get("created_timestamp") or ""
+    if ct:
+        ct = datetime.fromtimestamp(ct, timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
+    print("Created at:      ", ct)
+    print("Restricted:      ", "yes" if data.get("restricted", False) else "no")
+    print("Constraints:")
+    for name, constraint in sorted(data.get("definitions", {}).items()):
+        line = "  %-40s %10s" % (name, constraint.get("type", "any"))
+        if "values" in constraint:
+            line += " %s" % (tuple(constraint["values"]),)
+        rng = None
+        if "min" in constraint:
+            rng = [repr(constraint["min"]), ""]
+        if "max" in constraint:
+            if rng is None: rng = ["", ""]
+            rng[1] = repr(constraint["max"])
+        if rng is not None:
+            line += " [%s - %s]" % tuple(rng)
+        if "pattern" in constraint:
+            line += " ~ '%s'" % (constraint["pattern"])
+        print(line)
 
 class ListCommand(CLICommand):
 
@@ -38,37 +67,101 @@ class ShowCommand(CLICommand):
             if "-j" in opts or "--json" in opts:
                 print(json.dumps(data, indent=4, sort_keys=True))
             else:
-                print("Path:            ", data["path"])
-                print("Description:     ", data.get("description") or "")
-                print("Owner user:      ", data.get("owner_user", "") or "")
-                print("Owner role:      ", data.get("owner_role", "") or "")
-                print("Creator:         ", data.get("creator", ""))
-                ct = data.get("created_timestamp") or ""
-                if ct:
-                    ct = datetime.fromtimestamp(ct, timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
-                print("Created at:      ", ct)
-                print("Restricted:      ", "yes" if data.get("restricted", False) else "no")
-                print("Constraints:")
-                for name, constraint in sorted(data.get("definitions", {}).items()):
-                    line = "  %-40s %10s" % (name, constraint.get("type", "any"))
-                    if "values" in constraint:
-                        line += " %s" % (tuple(constraint["values"]),)
-                    rng = None
-                    if "min" in constraint:
-                        rng = [repr(constraint["min"]), ""]
-                    if "max" in constraint:
-                        if rng is None: rng = ["", ""]
-                        rng[1] = repr(constraint["max"])
-                    if rng is not None:
-                        line += " [%s - %s]" % tuple(rng)
-                    if "pattern" in constraint:
-                        line += " ~ '%s'" % (constraint["pattern"])
-                    print(line)
+                print_category(data)
 
+class CreateCommand(CLICommand):
+    Opts = "d:ro:p:j"
+    MinArgs = 1
+    Usage = """ [options] <category>        --create a category
+    -d description
+    -r restricted, default false
+    -o owner
+    -p parameter definitions (json file or dictionary)
+    -j json
+    """
+
+    def __call__(self, command, client, opts, args):
+        catname = args[0]
+        description = opts.get("-d")
+        if opts.get("-r"):
+            restricted = True
+        else:
+            restricted = False
+        if opts.get("-o"):
+            owner = opts.get("-o")
+        else:
+            owner = None
+
+        defs_file = opts.get("-p")
+        if defs_file:
+            defs = load_json(defs_file)
+            if not isinstance(defs, dict):
+                raise InvalidArguments("Definitions must be a dictionary")
+
+        cat = client.create_category(path=catname, owner_role=owner, restricted=restricted, description=description, definitions=defs)
+        if "-j" in opts:
+            print(json.dumps(cat))
+        else:
+            print_category(cat)
+
+class UpdateCommand(CLICommand):
+    Opts = "d:ro:p:m:j"
+    MinArgs = 1
+    Usage = """ [options] <category>        --update a category
+    -d description
+    -r restricted (true/false)
+    -o owner
+    -p parameter definitions (json file or dictionary)
+    -m mode (update, replace) - default: update
+    -j json
+    """
+
+    def __call__(self, command, client, opts, args):
+        catname = args[0]
+        description = opts.get("-d")
+        if opts.get("-r"):
+            restricted = opts.get("-r").lower() == "true"
+        else:
+            restricted = None
+        if opts.get("-o"):
+            owner = opts.get("-o")
+        else:
+            owner = None
+
+        defs_file = opts.get("-p")
+        if defs_file:
+            defs = load_json(defs_file)
+            if not isinstance(defs, dict):
+                raise InvalidArguments("Definitions must be a dictionary")
+        else:
+            defs = None
+
+        mode = opts.get("-m", "update")
+
+        cat = client.update_category(path=catname, owner_role=owner, restricted=restricted, description=description, definitions=defs, mode=mode)
+        if "-j" in opts:
+            print(json.dumps(cat))
+        else:
+            print_category(cat)
+
+class RemoveCommand(CLICommand):
+    Usage = """ <category>              --remove a category"""
+    MinArgs = 1
+
+    def __call__(self, command, client, opts, args):
+        cat_name = args[0]
+        try:
+            removed = client.remove_category(cat_name)
+        except MCError as e:
+            print(e)
+            sys.exit(1)
 
 
 CategoryCLI = CLI(
     "list",     ListCommand(),
-    "show",     ShowCommand()
+    "show",     ShowCommand(),
+    "create",   CreateCommand(),
+    "update",   UpdateCommand(),
+    "remove",   RemoveCommand()
 )
  

--- a/metacat/ui/metacat_category.py
+++ b/metacat/ui/metacat_category.py
@@ -17,9 +17,11 @@ def print_category(data):
         ct = datetime.fromtimestamp(ct, timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
     print("Created at:      ", ct)
     print("Restricted:      ", "yes" if data.get("restricted", False) else "no")
+    print("Required:        ", "yes" if data.get("required", False) else "no")
     print("Constraints:")
     for name, constraint in sorted(data.get("definitions", {}).items()):
-        line = "  %-40s %10s" % (name, constraint.get("type", "any"))
+        required = str(constraint.get("required", False)).strip().lower() == "true"
+        line = "  %-16s Required: %-24s %10s" % (name, "yes" if required else "no", constraint.get("type", "any"))
         if "values" in constraint:
             line += " %s" % (tuple(constraint["values"]),)
         rng = None
@@ -70,27 +72,42 @@ class ShowCommand(CLICommand):
                 print_category(data)
 
 class CreateCommand(CLICommand):
-    Opts = "d:ro:p:j"
+    Opts = "d:r:n:o:p:j"
     MinArgs = 1
     Usage = """ [options] <category>        --create a category
-    -d description
-    -r restricted, default false
-    -o owner
-    -p parameter definitions (json file or dictionary)
-    -j json
+    -d                      - description
+    -r                      - restricted (True/False), default False
+    -n                      - required (True/False), default False
+    -o                      - owner
+    -p                      - parameter definitions (json file or dictionary)
+    -j                      - print as JSON
     """
 
     def __call__(self, command, client, opts, args):
         catname = args[0]
         description = opts.get("-d")
-        if opts.get("-r"):
-            restricted = True
+        if "-r" in opts:
+            if opts.get("-r") == "True":
+                restricted = True
+            elif opts.get("-r") == "False":
+                restricted = False
+            else:
+                restricted = False
         else:
             restricted = False
-        if opts.get("-o"):
-            owner = opts.get("-o")
+
+        required = "-n" in opts
+        if "-n" in opts:
+           if opts.get("-n") == "True":
+               required = True
+           elif opts.get("-n") == "False":
+               required = False
+           else:
+               required = False
         else:
-            owner = None
+            required = False
+
+        owner = opts.get("-o")
 
         defs_file = opts.get("-p")
         if defs_file:
@@ -98,54 +115,55 @@ class CreateCommand(CLICommand):
             if not isinstance(defs, dict):
                 raise InvalidArguments("Definitions must be a dictionary")
 
-        cat = client.create_category(path=catname, owner_role=owner, restricted=restricted, description=description, definitions=defs)
+        cat = client.create_category(path=catname, owner_role=owner, restricted=restricted, required=required, description=description, definitions=defs)
         if "-j" in opts:
             print(json.dumps(cat))
         else:
             print_category(cat)
 
 class UpdateCommand(CLICommand):
-    Opts = "d:ro:p:m:j"
+    Opts = "d:r:n:o:p:m:j"
     MinArgs = 1
     Usage = """ [options] <category>        --update a category
-    -d description
-    -r restricted (true/false)
-    -o owner
-    -p parameter definitions (json file or dictionary)
-    -m mode (update, replace) - default: update
-    -j json
+    -d                      - description
+    -r                      - restricted (True/False)
+    -n                      - required (True/False)
+    -o                      - owner
+    -p                      - parameter definitions (json file or dictionary)
+    -m                      - mode (update, replace), default update
+    -j                      - print as JSON
     """
 
     def __call__(self, command, client, opts, args):
         catname = args[0]
-        description = opts.get("-d")
-        if opts.get("-r"):
-            restricted = opts.get("-r").lower() == "true"
-        else:
-            restricted = None
-        if opts.get("-o"):
-            owner = opts.get("-o")
-        else:
-            owner = None
+
+        updates = {}
+        if opts.get("-d") is not None:
+            updates["description"] = opts.get("-d")
+        if opts.get("-r") is not None:
+            updates["restricted"] = bool(opts.get("-r"))
+        if opts.get("-n") is not None:
+            updates["required"] = bool(opts.get("-n"))
+        if opts.get("-o") is not None:
+            updates["owner_role"] = opts.get("-o")
 
         defs_file = opts.get("-p")
         if defs_file:
             defs = load_json(defs_file)
             if not isinstance(defs, dict):
                 raise InvalidArguments("Definitions must be a dictionary")
-        else:
-            defs = None
+            updates["definitions"] = defs
 
-        mode = opts.get("-m", "update")
+        updates["mode"] = opts.get("-m", "update")
 
-        cat = client.update_category(path=catname, owner_role=owner, restricted=restricted, description=description, definitions=defs, mode=mode)
+        cat = client.update_category(path=catname, **updates)
         if "-j" in opts:
             print(json.dumps(cat))
         else:
             print_category(cat)
 
 class RemoveCommand(CLICommand):
-    Usage = """ <category>              --remove a category"""
+    Usage = """ <category>                  --remove a category"""
     MinArgs = 1
 
     def __call__(self, command, client, opts, args):

--- a/metacat/ui/metacat_category.py
+++ b/metacat/ui/metacat_category.py
@@ -40,7 +40,7 @@ class ListCommand(CLICommand):
 
     GNUStyle = True
     Opts = "j json"
-    Usage = """[options] [<root category>]
+    Usage = """ [options] [<root category>]
         -j|--json           - print as JSON
     """
 
@@ -59,7 +59,7 @@ class ShowCommand(CLICommand):
     GNUStyle = True
     Opts = "j json"
     MinArgs = 1
-    Usage = """[-j|--json] <category>
+    Usage = """ [-j|--json] <category>
         -j|--json           - print as JSON
     """
     
@@ -75,12 +75,12 @@ class CreateCommand(CLICommand):
     Opts = "d:r:n:o:p:j"
     MinArgs = 1
     Usage = """ [options] <category>        --create a category
-    -d                      - description
-    -r                      - restricted (True/False), default False
-    -n                      - required (True/False), default False
-    -o                      - owner
-    -p                      - parameter definitions (json file or dictionary)
-    -j                      - print as JSON
+    -d <description>                             - description of category
+    -r <True|False>                              - whether a category is restricted (cannot add extra fields to metadata), default False
+    -n <True|False>                              - whether a category is required (required field(s) must be present in metadata), default False
+    -o <owner>                                   - owner of category, default current user
+    -p <file|json>                               - parameter definitions as JSON file or inline JSON
+    -j                                           - print category information as JSON
     """
 
     def __call__(self, command, client, opts, args):
@@ -125,13 +125,13 @@ class UpdateCommand(CLICommand):
     Opts = "d:r:n:o:p:m:j"
     MinArgs = 1
     Usage = """ [options] <category>        --update a category
-    -d                      - description
-    -r                      - restricted (True/False)
-    -n                      - required (True/False)
-    -o                      - owner
-    -p                      - parameter definitions (json file or dictionary)
-    -m                      - mode (update, replace), default update
-    -j                      - print as JSON
+    -d <description>                            - description of category
+    -r <True|False>                             - whether a category is restricted (cannot add extra fields to metadata), default False
+    -n <True|False>                             - whether a category is required (required field(s) must be present in metadata), default False
+    -o <owner>                                  - owner of category, default current user
+    -p <file|json>                              - parameter definitions as JSON file or inline JSON
+    -m <update|replace>                         - mode for updating definitions, default update
+    -j                                          - print category information as JSON
     """
 
     def __call__(self, command, client, opts, args):

--- a/metacat/ui/metacat_file.py
+++ b/metacat/ui/metacat_file.py
@@ -86,7 +86,7 @@ class DeclareSingleCommand(CLICommand):
     Opts = ("N:p:m:c:da:s:P:jvf:", ["namespace=", "parents=", "metadata=", "checksums=", "dry-run", "auto-name", "size=", "json",
                     "file-description", "sample", "verbose"])
     Usage = """[options] [[<file namespace>:]<filename>] [<dataset namespace>:]<dataset name>
-    Declare signle file:
+    Declare single file:
         declare [options] [[<file namespace>:]<filename>] [<dataset namespace>:]<dataset name>
 
             -f|--file-description <JSON file>   - JSON file with description, including file attributes and metadata

--- a/metacat/ui/metacat_ui.py
+++ b/metacat/ui/metacat_ui.py
@@ -155,6 +155,15 @@ class ValidateMetadataCommand(CLICommand):
             # now shift to the metadata for checking
             meta = meta["metadata"]
 
+        # Check required parameters from required categories
+        for path, cat in self.Categories.items():
+            if cat.get("required") and cat.get("definitions"):
+                for pname, definition in cat["definitions"].items():
+                    if definition.get("required"):
+                        param_key = path + "." + pname
+                        if param_key not in meta:
+                            errors.append((param_key, f"required parameter '{pname}' is missing from category '{path}'"))
+
         for name, value in sorted(meta.items()):
             if not "." in name:
                 errors.append((name, f"Invalid metadata parameter name: {name} - must be <category>.<name>"))

--- a/metacat/util/validation.py
+++ b/metacat/util/validation.py
@@ -140,8 +140,4 @@ def validate_metadata(definitions, restricted, metadata={}, name=None, value=Non
                         else:
                             if value > vmax:    errors.append((name, f"value {value} out of range (max:{vmax})"))
 
-    for dname, definition in definitions.items():
-        if definition.get("required") and dname not in metadata:
-            errors.append((dname, "required parameter is missing"))
-    
     return errors

--- a/metacat/util/validation.py
+++ b/metacat/util/validation.py
@@ -140,4 +140,8 @@ def validate_metadata(definitions, restricted, metadata={}, name=None, value=Non
                         else:
                             if value > vmax:    errors.append((name, f"value {value} out of range (max:{vmax})"))
 
+    for dname, definition in definitions.items():
+        if definition.get("required") and dname not in metadata:
+            errors.append((dname, "required parameter is missing"))
+
     return errors

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1514,7 +1514,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
                 yield item
                 
     #
-    # Categiries
+    # Categories
     #
     def list_categories(self, root=None):
         """List namespaces
@@ -1546,7 +1546,72 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         """
         out = self.get_json(f"data/category/{path}")
         return out
+
+    def create_category(self, path=None, owner_role=None, restricted=False, description=None, definitions=None):
+        """Create a category
+
+        Arguments
+        ---------
+        path: string
+        parent_path: string, optional
+        owner_role: str, optional
+            if unspecified, the new category will be owned by the user
+        restricted: bool
+        description: string
+        definitions: dict
+        Returns
+        -------
+        dict
+            created category attributes
+        """
+
+        params = {
+            "path": path,
+            "owner_role": owner_role,
+            "restricted": restricted,
+            "description": description,
+            "definitions": definitions
+        }
+        return self.post_json(f"data/create_category", params)
+
+    def remove_category(self, path):
+        """Remove a category
+
+        Arguments
+        _________
+
+        category : str
         
+        """
+        return self.get_text(f"data/remove_category/{path}")
+
+    def update_category(self, path=None, owner_role=None, restricted=None, description=None, definitions=None, mode="update"):
+        """Update a category
+
+        Arguments
+        ---------
+        path: string
+        owner_role: str, optional
+        restricted: bool, optional
+        description: string, optional
+        definitions: dict, optional
+        mode: str, optional - "update" to merge, "replace" to overwrite (default: "update")
+
+        Returns
+        -------
+        dict
+            updated category attributes
+        """
+        params = {
+            "path": path,
+            "owner_role": owner_role,
+            "restricted": restricted,
+            "description": description,
+            "definitions": definitions,
+            "mode": mode
+        }
+        return self.post_json(f"data/update_category", params)
+
     #
     # Named queries
     #

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1547,7 +1547,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         out = self.get_json(f"data/category/{path}")
         return out
 
-    def create_category(self, path=None, owner_role=None, restricted=False, description=None, definitions=None):
+    def create_category(self, path=None, owner_role=None, restricted=False, required=False, description=None, definitions=None):
         """Create a category
 
         Arguments
@@ -1557,6 +1557,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         owner_role: str, optional
             if unspecified, the new category will be owned by the user
         restricted: bool
+        required: bool
         description: string
         definitions: dict
         Returns
@@ -1569,23 +1570,13 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
             "path": path,
             "owner_role": owner_role,
             "restricted": restricted,
+            "required": required,
             "description": description,
             "definitions": definitions
         }
         return self.post_json(f"data/create_category", params)
 
-    def remove_category(self, path):
-        """Remove a category
-
-        Arguments
-        _________
-
-        category : str
-        
-        """
-        return self.get_text(f"data/remove_category/{path}")
-
-    def update_category(self, path=None, owner_role=None, restricted=None, description=None, definitions=None, mode="update"):
+    def update_category(self, path=None, owner_role=None, restricted=None, required=None, description=None, definitions=None, mode="update"):
         """Update a category
 
         Arguments
@@ -1593,6 +1584,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         path: string
         owner_role: str, optional
         restricted: bool, optional
+        required: bool, optional
         description: string, optional
         definitions: dict, optional
         mode: str, optional - "update" to merge, "replace" to overwrite (default: "update")
@@ -1606,11 +1598,23 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
             "path": path,
             "owner_role": owner_role,
             "restricted": restricted,
+            "required": required,
             "description": description,
             "definitions": definitions,
             "mode": mode
         }
         return self.post_json(f"data/update_category", params)
+
+    def remove_category(self, path):
+        """Remove a category
+    
+        Arguments
+        _________
+
+        category : str
+        
+        """
+        return self.get_text(f"data/remove_category/{path}")
 
     #
     # Named queries

--- a/metacat/webapi/webapi.py
+++ b/metacat/webapi/webapi.py
@@ -1539,6 +1539,10 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
     def get_category(self, path):
         """Get category information
         
+        Arguments
+        ---------
+        path : str - category path
+
         Returns
         -------
         dict 
@@ -1552,18 +1556,19 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
 
         Arguments
         ---------
-        path: string
-        parent_path: string, optional
-        owner_role: str, optional
+        path: str - category path
+        parent_path: str, optional - path of parent category
+        owner_role: str, optional - owner or owner role of category
             if unspecified, the new category will be owned by the user
-        restricted: bool
-        required: bool
-        description: string
-        definitions: dict
+        restricted: bool - whether a category is restricted (cannot add extra fields to metadata), default False
+        required: bool - whether a category is required (required field(s) must be present in metadata), default False
+        description: str - description of category
+        definitions: dict - parameter definitions
+
         Returns
         -------
         dict
-            created category attributes
+            A dictionary with created category attributes
         """
 
         params = {
@@ -1581,18 +1586,18 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
 
         Arguments
         ---------
-        path: string
-        owner_role: str, optional
-        restricted: bool, optional
-        required: bool, optional
-        description: string, optional
-        definitions: dict, optional
+        path: str - category path
+        owner_role: str, optional - owner or owner role of category
+        restricted: bool, optional - whether a category is restricted (cannot add extra fields to metadata), default False
+        required: bool, optional - whether a category is required (required field(s) must be present in metadata), default False
+        description: string, optional - description of category
+        definitions: dict, optional - parameter definitions
         mode: str, optional - "update" to merge, "replace" to overwrite (default: "update")
 
         Returns
         -------
         dict
-            updated category attributes
+            A dictionary with updated category attributes
         """
         params = {
             "path": path,
@@ -1611,7 +1616,7 @@ class MetaCatClient(HTTPClient, TokenAuthClientMixin):
         Arguments
         _________
 
-        category : str
+        path : str - category path
         
         """
         return self.get_text(f"data/remove_category/{path}")

--- a/tests/env.py
+++ b/tests/env.py
@@ -12,7 +12,7 @@ if not production:
     sys.path.insert(0,base)
     sys.path.insert(0,f"{base}/tests/mocks")
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def env():
     if production:
        hostaport = 'https://metacat.fnal.gov:8143'
@@ -30,11 +30,11 @@ def env():
     os.environ['BEARER_TOKEN_FILE'] = '/tmp/bt_mc_test%d' % os.getpid()
     print("METACAT_SERVER_URL=", os.environ["METACAT_SERVER_URL"])
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def token(env):
     os.system("htgettoken -i hypot -a htvaultprod.fnal.gov ")
     
-@pytest.fixture
+@pytest.fixture(scope='session')
 def auth(token):
     os.system("metacat auth login -m token $USER")
     
@@ -76,3 +76,12 @@ def tst_file_md_list():
             os.unlink(md["name"])
         except:
             pass
+
+# define definitions for testing categories
+@pytest.fixture
+def tst_defs():
+    tst_defs = {
+        "intfield": {"type": "int", "min": 0, "max": 10, "required": "True"},
+        "textfield": {"type": "text", "values": ["a", "b", "c", "d"]}
+    }
+    return tst_defs

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -10,7 +10,7 @@ import pytest
 import json
 import time
 
-from env import env, token, auth, start_ds, tst_ds, tst_file_md_list
+from env import env, token, auth, start_ds, tst_ds, tst_file_md_list, tst_defs
 
 
 # need tests for at least:
@@ -302,19 +302,56 @@ def test_metacat_namespace_show(auth, tst_ds):
     assert data.find(ns) >= 0
 
 
-# Categories -- Don't know how to add them, they show up empty
-#    in hypot, nothing to test?!?
-#
-# def x_test_metacat_category_list(auth):
-#    with os.popen("metacat category list", "r") as fin:
-#        data = fin.read()
-#        # check output
-#
-# def x_test_metacat_category_show(auth):
-#    with os.popen("metacat category show", "r") as fin:
-#        data = fin.read()
-#        # check output
-#
+# Categories
+
+def test_metacat_category_create(auth, tst_defs):
+    with open("defs", "w") as defs:
+        json.dump(tst_defs, defs)
+    with os.popen(f"metacat category create -d 'testing' -p defs test_category") as fin:
+        data = fin.read()
+    os.unlink("defs")
+    assert data.find(os.environ["USER"]) > 0
+    assert data.find("test_category") > 0
+    assert data.find("intfield") > 0
+
+def test_metacat_category_list(auth):
+    with os.popen("metacat category list", "r") as fin:
+        data = fin.read()
+    assert data.find("test_category") > 0
+    assert data.find("cat_t1") > 0
+
+def test_metacat_category_show(auth):
+    with os.popen("metacat category show test_category", "r") as fin:
+        data = fin.read()
+    assert data.find("test_category") > 0
+    assert data.find("Restricted") > 0
+    assert data.find("int") > 0
+
+def test_metacat_category_update(auth, tst_defs):
+    tst_defs["newfield"] = {"type": "float", "min": 1.2, "max": 4.7}
+    with open("defs", "w") as defs:
+        json.dump(tst_defs, defs)
+    os.system(f"metacat category update -p defs test_category")
+    os.unlink("defs")
+    with os.popen(f"metacat category show test_category") as fin:
+        data = fin.read()
+    assert data.find("newfield") > 0
+
+def test_metacat_category_validation(auth, tst_ds, tst_file_md_list):
+    ns = tst_file_md_list[1]["namespace"]
+    fname = tst_file_md_list[1]["name"]
+    md = '{"test_category.newfield": 8.9}'
+    with os.popen(f"metacat file update-meta -f {ns}:{name} {md}") as fin:
+        data = fin.read()
+    assert data.find("InvalidMetadataError")
+
+def test_metacat_category_remove(auth):
+    os.system(f"metacat category remove test_category")
+    with os.popen(f"metacat category list") as fin:
+        data = fin.read()
+    assert data.find("test_category") < 0
+
+
 def test_metacat_file_declare_sample(auth):
     with os.popen("metacat file declare-sample", "r") as fin:
         data = fin.read()

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -305,52 +305,135 @@ def test_metacat_namespace_show(auth, tst_ds):
 # Categories
 
 def test_metacat_category_create(auth, tst_defs):
-    with open("defs", "w") as defs:
-        json.dump(tst_defs, defs)
-    with os.popen(f"metacat category create -d 'testing' -p defs test_category") as fin:
+    with open("defs", "w") as f:
+        json.dump(tst_defs, f)
+    with os.popen(f"metacat category create -d 'testing with pytest' -p defs pytest_category") as fin:
         data = fin.read()
     os.unlink("defs")
-    assert data.find(os.environ["USER"]) > 0
-    assert data.find("test_category") > 0
-    assert data.find("intfield") > 0
+    assert data.find(os.environ["USER"]) >= 0
+    assert data.find("pytest_category") >= 0
+    assert data.find("intfield") >= 0
 
 def test_metacat_category_list(auth):
     with os.popen("metacat category list", "r") as fin:
         data = fin.read()
-    assert data.find("test_category") > 0
-    assert data.find("cat_t1") > 0
+    assert data.find("pytest_category") >= 0
+    assert data.find("cat_t1") >= 0
 
 def test_metacat_category_show(auth):
-    with os.popen("metacat category show test_category", "r") as fin:
+    with os.popen("metacat category show pytest_category", "r") as fin:
         data = fin.read()
-    assert data.find("test_category") > 0
-    assert data.find("Restricted") > 0
-    assert data.find("int") > 0
+    assert data.find("pytest_category") >= 0
+    assert data.find("Restricted") >= 0
+    assert data.find("int") >= 0
 
 def test_metacat_category_update(auth, tst_defs):
     tst_defs["newfield"] = {"type": "float", "min": 1.2, "max": 4.7}
     with open("defs", "w") as defs:
         json.dump(tst_defs, defs)
-    os.system(f"metacat category update -p defs test_category")
+    os.system(f"metacat category update -p defs pytest_category")
     os.unlink("defs")
-    with os.popen(f"metacat category show test_category") as fin:
+    with os.popen(f"metacat category show pytest_category") as fin:
         data = fin.read()
-    assert data.find("newfield") > 0
+    assert data.find("newfield") >= 0
 
 def test_metacat_category_validation(auth, tst_ds, tst_file_md_list):
+    # adding metadata that fits the definitions, should succeed
     ns = tst_file_md_list[1]["namespace"]
-    fname = tst_file_md_list[1]["name"]
-    md = '{"test_category.newfield": 8.9}'
-    with os.popen(f"metacat file update-meta -f {ns}:{name} {md}") as fin:
+    name = tst_file_md_list[1]["name"]+"c"
+    md = '{"pytest_category.intfield": 2}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds}") as fin:
         data = fin.read()
-    assert data.find("InvalidMetadataError")
+    assert data.find(ns) >= 0
+    assert data.find("Invalid metadata") < 0
+
+def test_metacat_category_validation2(auth, tst_ds, tst_file_md_list):
+    # adding metadata outside the range of the definitions, should fail
+    ns = tst_file_md_list[2]["namespace"]
+    name = tst_file_md_list[2]["name"]+"c"
+    md = '{"pytest_category.newfield": 8.9}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds} 2>&1") as fin:
+        data = fin.read()
+    assert data.find("Invalid metadata") >= 0
+    assert data.find("Metadata category validation errors") >= 0
+    assert data.find("out of range") >= 0
+
+def test_metacat_category_nonrestricted(auth, tst_ds, tst_file_md_list):
+    # metadata includes an undefined parameter in a non-restricted category, should succeed
+    ns = tst_file_md_list[2]["namespace"]
+    name = tst_file_md_list[2]["name"]+"c"
+    md = '{"pytest_category.extra": 7.2}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds}") as fin:
+        data = fin.read()
+    assert data.find(ns) >= 0
+    assert data.find("Invalid metadata") < 0
+
+def test_metacat_category_create2(auth, tst_defs):
+    # testing creation of a category that is restricted and required
+    with open("defs", "w") as f:
+        json.dump(tst_defs, f)
+    with os.popen(f"metacat category create -d 'testing restricted and required with pytest' -r True -n True -p defs pytest_category_rr") as fin:
+        data = fin.read()
+    os.unlink("defs")
+    assert data.find("pytest_category_rr") >= 0
+    assert data.find("yes") >= 0
+    
+def test_metacat_category_validation3(auth, tst_ds, tst_file_md_list):
+    # adding metadata that fits the definitions in the restricted, required category, should succeed
+    ns = tst_file_md_list[3]["namespace"]
+    name = tst_file_md_list[3]["name"]+"c"
+    md = '{"pytest_category_rr.intfield": 2}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds}") as fin:
+        data = fin.read()
+    assert data.find(ns) >= 0
+    assert data.find("Invalid metadata") < 0
+
+def test_metacat_categroy_validation4(auth, tst_ds, tst_file_md_list):
+    # adding metadata outside the range of the definitions in the restricted, required category, should fail
+    ns = tst_file_md_list[4]["namespace"]
+    name = tst_file_md_list[4]["name"]+"c"
+    md = '{"pytest_category_rr.newfield": 8.9}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds} 2>&1") as fin:
+        data = fin.read()
+    assert data.find("Invalid metadata") >= 0
+    assert data.find("Metadata category validation errors") >= 0
+
+def test_metacat_category_restricted(auth, tst_ds, tst_file_md_list):
+    # adding unallowed metadata field to a restricted category, should fail
+    ns = tst_file_md_list[4]["namespace"]
+    name = tst_file_md_list[4]["name"]+"c"
+    md = '{"pytest_category_rr.extra": "abc"}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds} 2>&1") as fin:
+        data = fin.read()
+    assert data.find("Invalid metadata") >= 0
+    assert data.find("parameter not allowed in restricted category") >= 0
+
+def test_metacat_category_requiredparam(auth, tst_ds, tst_file_md_list):
+    # not adding a required parameter, should fail
+    ns = tst_file_md_list[4]["namespace"]
+    name = tst_file_md_list[4]["name"]+"c"
+    md = '{"pytest_category_rr.textfield": "a"}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds} 2>&1") as fin:
+        data = fin.read()
+    assert data.find("Invalid metadata") >= 0
+    assert data.find("missing from category") >= 0
+
+def test_metacat_category_requiredcat(auth, tst_ds, tst_file_md_list):
+    # not adding a required category, should fail
+    ns = tst_file_md_list[4]["namespace"]
+    name = tst_file_md_list[4]["name"]+"c"
+    md = '{"pytest_category.intfield": 4}'
+    with os.popen(f"metacat file declare -m '{md}' {ns}:{name} {tst_ds} 2>&1") as fin:
+        data = fin.read()
+    assert data.find("Invalid metadata") >= 0
+    assert data.find("missing from category") >= 0
 
 def test_metacat_category_remove(auth):
-    os.system(f"metacat category remove test_category")
+    os.system(f"metacat category remove pytest_category")
+    os.system(f"metacat category remove pytest_category_rr")
     with os.popen(f"metacat category list") as fin:
         data = fin.read()
-    assert data.find("test_category") < 0
-
+    assert data.find("pytest_category") < 0
 
 def test_metacat_file_declare_sample(auth):
     with os.popen("metacat file declare-sample", "r") as fin:

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -5,7 +5,7 @@ from metacat.db import DBFile, DBDataset, DBFileSet, DBNamedQuery, DBUser, DBNam
     DBParamCategory, parse_name, AlreadyExistsError, IntegrityError, MetaValidationError
 from wsdbtools import ConnectionPool
 from urllib.parse import quote_plus, unquote_plus
-from metacat.util import to_str, to_bytes, ObjectSpec
+from metacat.util import to_str, to_bytes, ObjectSpec, validate_metadata
 from metacat.mql import MQLQuery, MQLSyntaxError, MQLExecutionError, MQLCompilationError, MQLError
 from metacat import Version
 from datetime import datetime, timezone
@@ -600,27 +600,28 @@ class DataHandler(MetaCatHandler):
             return tuple(path.rsplit(".",1))
         else:
             return ".", path
-        
-    def validate_metadata(self, data):
-        categories = self.load_categories()
-        invalid = []
-        for k, v in data.items():
-            path, name = self.split_cat(k)
-            cat = categories.get(path)
-            if cat is None:
-                while True:
-                    path, _ = self.split_cat(path)
-                    if path in categories:
-                        if categories[path].Restricted:
-                            invalid.append({"name":k, "value":v, "reason":f"Category {path} is restricted"})
-                        break
-                    if path == ".":
-                        break
-            else:
-                valid, reason = cat.validate_parameter(name, v)
-                if not valid:
-                    invalid.append({"name":k, "value":v, "reason":reason})
-        return invalid
+
+# should be using metadata validation code from util/validation.py        
+#    def validate_metadata(self, data):
+#        categories = self.load_categories()
+#        invalid = []
+#        for k, v in data.items():
+#            path, name = self.split_cat(k)
+#            cat = categories.get(path)
+#            if cat is None:
+#                while True:
+#                    path, _ = self.split_cat(path)
+#                    if path in categories:
+#                        if categories[path].Restricted:
+#                            invalid.append({"name":k, "value":v, "reason":f"Category {path} is restricted"})
+#                        break
+#                    if path == ".":
+#                        break
+#            else:
+#                valid, reason = cat.validate_parameter(name, v)
+#                if not valid:
+#                    invalid.append({"name":k, "value":v, "reason":reason})
+#        return invalid
         
     @sanitized
     def declare_files(self, request, relpath, namespace=None, dataset=None, dry_run="no", **args):
@@ -951,8 +952,9 @@ class DataHandler(MetaCatHandler):
         return json.dumps({"files_moved": nmoved, "errors":errors[:self.MAX_ERRORS], "nerrors":nerrors}), "application/json"
 
     def __update_meta_bulk(self, db, user, new_meta, mode, names=None, ids=None):
-        metadata_errors = self.validate_metadata(new_meta)
+        metadata_errors = DBParamCategory.validate_metadata_bulk(db, [new_meta])
         if metadata_errors:
+            metadata_errors = metadata_errors[0][1]  # Get errors from first (only) item
             return METADATA_ERROR_CODE, json.dumps({
                 "message":"Metadata validation errors",
                 "metadata_errors":metadata_errors

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -1524,7 +1524,93 @@ class DataHandler(MetaCatHandler):
         else:
             out = cat.to_jsonable()
         return json.dumps(out), "application/json"
-        
+
+    @sanitized
+    def create_category(self, request, relpath):
+        db = self.App.connect()
+        user, error = self.authenticated_user()
+        if not (user and user.is_admin()):
+            return 403, "Permission denied -- must be admin"
+        if not request.body:
+            return 400, "Category parameters are not specified"
+
+        params = json.loads(request.body)
+        path = params["path"]
+        owner_role = params["owner_role"]
+        restricted = params["restricted"]
+        description = params["description"]
+        definitions = params["definitions"]
+        creator = user.Username
+
+        if not path:
+            return 404, "Category path not specified"
+        if '.' in path and path != '.':
+            return 409, "Invalid relative category path. Cannot contain dot"
+        if DBParamCategory.exists(db, path):
+            return 409, f"Category {path} already exists" 
+        if not definitions:
+            return 400, "Empty category definitions"
+
+        cat = DBParamCategory(db, path, restricted=restricted, owner_role=owner_role, owner_user=creator, creator=creator, description=description, definitions=definitions)
+        cat.create()
+        return json.dumps(cat.to_jsonable()), "application/json"
+
+    @sanitized
+    def remove_category(self, request, relpath, path=None, **args):
+        path = path or relpath
+        if not path:
+            return 400, "Category path not specified", "text/plain"
+        db = self.App.connect()
+        user, error = self.authenticated_user()
+        cat = DBParamCategory.get(db, path)
+        if cat is None:
+            return 404, "Category not found"
+        if not (user.is_admin() or user in cat.owners()):
+            return 403, "Permission denied"
+        cat.delete()
+        return "null", "text/json"
+
+    @sanitized
+    def update_category(self, request, relpath):
+        db = self.App.connect()
+        user, error = self.authenticated_user()
+        if not (user and user.is_admin()):
+            return 403, "Permission denied -- must be admin"
+        if not request.body:
+            return 400, "Category parameters are not specified"
+
+        params = json.loads(request.body)
+        path = params.get("path")
+        if not path:
+            return 400, "Category path not specified"
+
+        cat = DBParamCategory.get(db, path)
+        if cat is None:
+            return 404, "Category not found"
+
+        owner_role = params.get("owner_role")
+        restricted = params.get("restricted")
+        description = params.get("description")
+        definitions = params.get("definitions")
+        mode = params.get("mode", "update")
+
+        if owner_role is not None:
+            cat.OwnerRole = owner_role
+        if restricted is not None:
+            cat.Restricted = restricted
+        if description is not None:
+            cat.Description = description
+        if definitions is not None:
+            if mode == "update":
+                new_defs = cat.Definitions.copy()
+                new_defs.update(definitions)
+                cat.Definitions = new_defs
+            else:
+                cat.Definitions = definitions
+
+        cat.save()
+        return json.dumps(cat.to_jsonable()), "application/json"
+
     @sanitized
     def report_metadata_keys(self, request, replpath,  **args):
         db = self.App.connect()

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -1540,6 +1540,7 @@ class DataHandler(MetaCatHandler):
         path = params["path"]
         owner_role = params["owner_role"]
         restricted = params["restricted"]
+        required = params["required"]
         description = params["description"]
         definitions = params["definitions"]
         creator = user.Username
@@ -1549,28 +1550,22 @@ class DataHandler(MetaCatHandler):
         if '.' in path and path != '.':
             return 409, "Invalid relative category path. Cannot contain dot"
         if DBParamCategory.exists(db, path):
-            return 409, f"Category {path} already exists" 
+            return 409, f"Category {path} already exists"
         if not definitions:
             return 400, "Empty category definitions"
 
-        cat = DBParamCategory(db, path, restricted=restricted, owner_role=owner_role, owner_user=creator, creator=creator, description=description, definitions=definitions)
+        # Validate that required categories have at least one required parameter
+        if required:
+            has_required_param = any(
+                defn.get("required")
+                for defn in definitions.values()
+            )
+            if not has_required_param:
+                return 400, "Required category must have at least one required parameter"
+
+        cat = DBParamCategory(db, path, restricted=restricted, required=required, owner_role=owner_role, owner_user=creator, creator=creator, description=description, definitions=definitions)
         cat.create()
         return json.dumps(cat.to_jsonable()), "application/json"
-
-    @sanitized
-    def remove_category(self, request, relpath, path=None, **args):
-        path = path or relpath
-        if not path:
-            return 400, "Category path not specified", "text/plain"
-        db = self.App.connect()
-        user, error = self.authenticated_user()
-        cat = DBParamCategory.get(db, path)
-        if cat is None:
-            return 404, "Category not found"
-        if not (user.is_admin() or user in cat.owners()):
-            return 403, "Permission denied"
-        cat.delete()
-        return "null", "text/json"
 
     @sanitized
     def update_category(self, request, relpath):
@@ -1592,6 +1587,7 @@ class DataHandler(MetaCatHandler):
 
         owner_role = params.get("owner_role")
         restricted = params.get("restricted")
+        required = params.get("required")
         description = params.get("description")
         definitions = params.get("definitions")
         mode = params.get("mode", "update")
@@ -1600,6 +1596,8 @@ class DataHandler(MetaCatHandler):
             cat.OwnerRole = owner_role
         if restricted is not None:
             cat.Restricted = restricted
+        if required is not None:
+            cat.Required = required
         if description is not None:
             cat.Description = description
         if definitions is not None:
@@ -1610,8 +1608,33 @@ class DataHandler(MetaCatHandler):
             else:
                 cat.Definitions = definitions
 
+        # Validate that required categories have at least one required parameter
+        if required is not None or definitions is not None:
+            if cat.Required:
+                has_required_param = any(
+                    defn.get("required")
+                    for defn in cat.Definitions.values()
+                )
+                if not has_required_param:
+                    return 400, "Required category must have at least one required parameter"
+
         cat.save()
         return json.dumps(cat.to_jsonable()), "application/json"
+
+    @sanitized
+    def remove_category(self, request, relpath, path=None, **args):
+        path = path or relpath
+        if not path:
+            return 400, "Category path not specified", "text/plain"
+        db = self.App.connect()
+        user, error = self.authenticated_user()
+        cat = DBParamCategory.get(db, path)
+        if cat is None:
+            return 404, "Category not found"
+        if not (user.is_admin() or user in cat.owners()):
+            return 403, "Permission denied"
+        cat.delete()
+        return "null", "text/json"
 
     @sanitized
     def report_metadata_keys(self, request, replpath,  **args):

--- a/webserver/data_handler.py
+++ b/webserver/data_handler.py
@@ -601,28 +601,6 @@ class DataHandler(MetaCatHandler):
         else:
             return ".", path
 
-# should be using metadata validation code from util/validation.py        
-#    def validate_metadata(self, data):
-#        categories = self.load_categories()
-#        invalid = []
-#        for k, v in data.items():
-#            path, name = self.split_cat(k)
-#            cat = categories.get(path)
-#            if cat is None:
-#                while True:
-#                    path, _ = self.split_cat(path)
-#                    if path in categories:
-#                        if categories[path].Restricted:
-#                            invalid.append({"name":k, "value":v, "reason":f"Category {path} is restricted"})
-#                        break
-#                    if path == ".":
-#                        break
-#            else:
-#                valid, reason = cat.validate_parameter(name, v)
-#                if not valid:
-#                    invalid.append({"name":k, "value":v, "reason":reason})
-#        return invalid
-        
     @sanitized
     def declare_files(self, request, relpath, namespace=None, dataset=None, dry_run="no", **args):
         # Declare new files, add to the dataset

--- a/webserver/gui_handler.py
+++ b/webserver/gui_handler.py
@@ -124,7 +124,7 @@ class GUICategoryHandler(MetaCatHandler):
             self.redirect(self.scriptUri() + "/auth/login?redirect=" + self.scriptUri() + "/gui/categories/index")
         rpath = request.POST["rpath"]
         if '.' in rpath and rpath != '.':
-            self.redirect("./index?error=%s" % (quote_plus("Invaid relative category path. Can not contain dot."),))
+            self.redirect("./index?error=%s" % (quote_plus("Invalid relative category path. Can not contain dot."),))
         parent_path = request.POST.get("parent_path")
         if not parent_path:
             if not me.is_admin():
@@ -731,7 +731,7 @@ class GUIHandler(MetaCatHandler):
     def namespaces(self, request, relpath, all="no", **args):
         user, auth_error = self.authenticated_user()
         if not user: 
-            self.redirect(self.scriptUri() + "/auth/login?redirect=" + self.scriptUri() + f"gui/namespaces?all={all}")
+            self.redirect(self.scriptUri() + "/auth/login?redirect=" + self.scriptUri() + f"/gui/namespaces?all={all}")
         db = self.App.connect()
         all = all == "yes"
         if all:

--- a/webserver/gui_handler.py
+++ b/webserver/gui_handler.py
@@ -22,7 +22,7 @@ class GUICategoryHandler(MetaCatHandler):
     index = categories
 
     @sanitize()
-    def show(self, request, relpath, path=None):
+    def show(self, request, relpath, path=None, **args):
         me, auth_error = self.authenticated_user()
         if not me:
             self.redirect(self.scriptUri() + "/auth/login?redirect=" + self.scriptUri() + "/gui/show")
@@ -39,7 +39,8 @@ class GUICategoryHandler(MetaCatHandler):
             print(name, d)
         return self.render_to_response("category.html", category=cat, edit=edit, create=False, roles=roles, admin=admin, user=me,
             users = users,
-            types = DBParamCategory.Types)
+            types = DBParamCategory.Types,
+            **self.messages(args))
         
     @sanitize()
     def create(self, request, relpath):
@@ -77,39 +78,41 @@ class GUICategoryHandler(MetaCatHandler):
                         values = values.split(",") if values else None
                         minv = form.get(f"param:{param_id}:min", "").strip() or None
                         maxv = form.get(f"param:{param_id}:max", "").strip() or None
-                
+
                         if type in ("int", "int[]"):
-                            if minv is not None:    
+                            if minv is not None:
                                 try:    minv = int(minv)
                                 except: minv = None
-                            if maxv is not None:    
+                            if maxv is not None:
                                 try:    maxv = int(maxv)
                                 except: maxv = None
-                            if values:  
+                            if values:
                                 try:    values = [int(x) for x in values]
                                 except: values = None
                         elif type in ("float", "float[]"):
-                            if minv is not None:    
+                            if minv is not None:
                                 try:    minv = float(minv)
                                 except: minv = None
-                            if maxv is not None:    
+                            if maxv is not None:
                                 try:    maxv = float(maxv)
                                 except: maxv = None
-                            if values:  
+                            if values:
                                 try:    values = [float(x) for x in values]
                                 except: values = None
                         elif type in ("boolean", "boolean[]", "any"):
                             minv = maxv = values = None     # meaningless
-                            
+
                         pdef = {"type":type}
 
                         if type in ("text", "text[]"):
                             pattern = form.get(f"param:{param_id}:pattern", "").strip() or None
                             if pattern: pdef["pattern"] = pattern
-                            
+
                         if minv is not None:    pdef["min"] = minv
                         if maxv is not None:    pdef["max"] = maxv
                         if values is not None:    pdef["values"] = values
+                        if form.get(f"param:{param_id}:required"):
+                            pdef["required"] = True
                         defs[name] = pdef
                         #print("pdef:", pdef)
         for n in removals:
@@ -151,8 +154,19 @@ class GUICategoryHandler(MetaCatHandler):
         #print("owner_user, owner_role:", owner_user, owner_role)
         
         restricted = request.POST.get("restricted", False)
+        required = request.POST.get("required", False)
         definitions = self.read_parameter_definitions(request.POST)
-        cat = DBParamCategory(db, path, restricted=restricted, owner_role=owner_role, 
+
+        # Validate that required categories have at least one required parameter
+        if required:
+            has_required_param = any(
+                defn.get("required")
+                for defn in definitions.values()
+            )
+            if not has_required_param:
+                self.redirect("./index?error=%s" % (quote_plus("Required category must have at least one required parameter"),))
+
+        cat = DBParamCategory(db, path, restricted=restricted, required=required, owner_role=owner_role,
             owner_user=owner_user,
             creator = me.Username, description=request.POST["description"],
             definitions = definitions)
@@ -179,6 +193,10 @@ class GUICategoryHandler(MetaCatHandler):
 
         if not (me.is_admin() or me.Username in cat.owners()):
             self.redirect("./index?error=%s" % (quote_plus(f"Permission denied"),))
+
+        if request.POST.get("delete"):
+            cat.delete()
+            self.redirect("./index")
             
         if me.is_admin():
             new_owner = request.POST.get("owner")
@@ -194,7 +212,18 @@ class GUICategoryHandler(MetaCatHandler):
             
         cat.Description = request.POST["description"]
         cat.Restricted = "restricted" in request.POST
+        cat.Required = "required" in request.POST
         defs = self.read_parameter_definitions(request.POST)
+
+        # Validate that required categories have at least one required parameter
+        if cat.Required:
+            has_required_param = any(
+                defn.get("required")
+                for defn in defs.values()
+            )
+            if not has_required_param:
+                self.redirect("./index?error=%s" % (quote_plus("Required category must have at least one required parameter"),))
+
         cat.Definitions = defs
         cat.save()
         self.redirect(f"./show?path={path}")

--- a/webserver/templates/categories.html
+++ b/webserver/templates/categories.html
@@ -13,6 +13,7 @@
 		<th>Path</th>
 		<th>Owner</th>
         <th>Restricted</th>
+        <th>Required</th>
 		<th>Description</th>
 	</tr>
     {% for cat in categories %}
@@ -24,6 +25,7 @@
                 {% endif %}
             </td>
             <td>{{'yes' if cat.Restricted else 'no'}}</td>
+            <td>{{'yes' if cat.Required else 'no'}}</td>
             <td>{{cat.Description or ""}}</td>
         </tr>
     {% endfor %}

--- a/webserver/templates/category.html
+++ b/webserver/templates/category.html
@@ -83,6 +83,15 @@
         </td>
     </tr>
     <tr>
+        <th>Required</th>
+        <td>
+            {% if edit or create %}
+                <input type="checkbox" name="required" {% if category and category.Required %} checked="checked" {% endif %}/>
+            {% else %}
+                {{'yes' if category.Required else 'no'}}
+            {% endif %}
+        </td>
+    <tr>
         <th>Owner</th>
         <td>
             {% if edit or create %}
@@ -117,6 +126,7 @@
                     <th>Max</th>
                     <th>Values</th>
                     <th>Pattern</th>
+                    <th>Required</th>
                     {% if edit %}
                         <td>delete</td>
                     {% endif %}
@@ -132,11 +142,12 @@
                             </td>
                             <td><input type="text" name="param:1_{{loop.index}}:min" value="{{definition['min']|default('')}}"/></td>
                             <td><input type="text" name="param:1_{{loop.index}}:max" value="{{definition['max']|default('')}}"/></td>
-                            <td><input type="text" name="param:1_{{loop.index}}:values" 
+                            <td><input type="text" name="param:1_{{loop.index}}:values"
                                 {% if "values" in definition and definition['values'] %}
                                     value="{{definition['values']|join(',')}}"
                                 {% endif %}/></td>
                             <td><input type="text" name="param:1_{{loop.index}}:pattern" value="{{definition['pattern'] or ''}}"/></td>
+                            <td><input type="checkbox" name="param:1_{{loop.index}}:required" {% if definition.get('required') %}checked="checked"{% endif %}/></td>
                             {% if edit %}
                                 <td><input type="checkbox" name="param:1_{{loop.index}}:remove"></td>
                             {% endif %}
@@ -158,6 +169,7 @@
                             <td><input type="text" name="param:2_{{loop.index}}:max"/></td>
                             <td><input type="text" name="param:2_{{loop.index}}:values"/></td>
                             <td><input type="text" name="param:2_{{loop.index}}:pattern"/></td>
+                            <td><input type="checkbox" name="param:2_{{loop.index}}:required"/></td>
                             {% if edit %}
                                 <td></td>
                             {% endif %}
@@ -173,6 +185,7 @@
                             <td>{{definition.get("max", "")}}</td>
                             <td>{{definition.get("values", [])|join(',') or ""}}</td>
                             <td>{{definition.get("pattern", "")}}</td>
+                            <td>{{'yes' if definition.get('required') else 'no'}}</td>
                             {% if edit %}
                                 <td></td>
                             {% endif %}
@@ -185,6 +198,10 @@
 	{% if edit or create %}
         <tr><td></td><td><input type="submit" value="{{'Save' if edit else 'Create'}}"/></td>
 	    </tr>
+    {% endif %}
+        {% if edit %}
+        <tr><td></td><td><input type="submit" name="delete" value="Delete" style="background-color: #d9534f; color: white;" onclick="return confirm('Are you sure you want to delete this category?');"/></td>
+            </tr>
     {% endif %}
 </table>
 

--- a/webserver/templates/create_category.html
+++ b/webserver/templates/create_category.html
@@ -30,6 +30,10 @@
         <td><input type="checkbox" name="restricted"/></td>
     </tr>
     <tr>
+        <th>Required</th>
+        <td><input type="checkbox" name="required"/></td>
+    </tr>
+    <tr>
         <th>Owner role</th>
         </td>
                 <select name="owner">


### PR DESCRIPTION
This adds CLI commands and API calls for category management - create, update, and remove. Only admins are allowed to use these commands.
Also adds the ability to mark categories as required, when there are required parameters within the category, and updates the validation functionality to handle this. It also adds a column to the database to indicate whether the category is required.
Updated the CLI output and web gui to support required categories/parameters.
Added tests for the commands and functionality of the category validation, and added documentation for the new commands.
Also snuck in a fix for a metacat gui page not redirecting correctly.
This should resolve #100 