### PR TITLE
Allow setting ownership of  per-user namespaces (for Dune)

### DIFF
--- a/daemon/daemon.py
+++ b/daemon/daemon.py
@@ -37,6 +37,7 @@ class MetaCatDaemon(Logged):
             raise ValueError("Token file, or X.509 cert and key files are not in the configuration")
 
         self.UserNamespaceTemplate = daemon_config.get("user_namespace_template", "")
+        self.UserNamespaceOwner = daemon_config.get("user_namespace_owner", "")
         self.FerryUpdateInterval = daemon_config.get("ferry_update_interval", 1 * 3600)
         self.CountsUpdateInterval = daemon_config.get("counts_update_interval", 1 * 3600)
         self.VO = daemon_config["vo"]
@@ -218,8 +219,13 @@ class MetaCatDaemon(Logged):
             # add namespace for user, if configured
             if self.UserNamespaceTemplate:
                 uns = self.UserNamespaceTemplate.replace('$username', username)
+                if self.UserNamespaceOwner:
+                    owndict = {"owner_role": self.UserNamespaceOwner}
+                else:
+                    owndict = {"owner_user": username}
+
                 if not DBNamespace.exists(db, uns):
-                    ns = DBNamespace(db, uns, owner_user=username )
+                    ns = DBNamespace(db, uns, **owndict)
                     ns_created.append(uns)
                     ns.Creator = username
                     ns.create()

--- a/daemon/demo_m_f.yaml.sample
+++ b/daemon/demo_m_f.yaml.sample
@@ -1,0 +1,23 @@
+
+ssl:
+  cert: ./certs/cert.pem
+  key:  ./certs/key.pem
+
+daemon:
+  vo: hypot
+  ferry_url: https://ferryhost.some.domain:12345
+  ferry_update_interval: 3600
+  counts_update_interval: 14400
+  role_pattern: Role=(.*)(read|write)
+  role_template: $1_$2
+  user_namespace_template: user.$user.fnal.gov   
+  user_namespace_owner: admin_role
+
+database:
+  host:     dbhost.some.domain
+  port:     1234
+  dbname:   hypot_db_name
+  user:     hypot_db_user
+  password: redacted
+  schema:   metacat
+


### PR DESCRIPTION
Dune actually wants per-user-namepaces that belong to the admin_role, so you can restrict what goes in them. 
So yet another config option:

```
daemon:
  user_namespace_template: user.$username.fnal.gov
  user_namespace_owner: admin_role
```

if you omit the `user_namespace_owner`, the groups belong to the user. 